### PR TITLE
Add materialization_embeddings option to materialization API

### DIFF
--- a/robosystems_client/extensions/materialization_client.py
+++ b/robosystems_client/extensions/materialization_client.py
@@ -27,6 +27,7 @@ class MaterializationOptions:
   ignore_errors: bool = True
   rebuild: bool = False
   force: bool = False
+  materialize_embeddings: bool = False
   on_progress: Optional[Callable[[str], None]] = None
   timeout: Optional[int] = 600  # 10 minute default timeout
 
@@ -112,6 +113,7 @@ class MaterializationClient:
         ignore_errors=options.ignore_errors,
         rebuild=options.rebuild,
         force=options.force,
+        materialize_embeddings=options.materialize_embeddings,
       )
 
       from ..client import AuthenticatedClient

--- a/robosystems_client/models/materialize_request.py
+++ b/robosystems_client/models/materialize_request.py
@@ -22,6 +22,9 @@ class MaterializeRequest:
       source (None | str | Unset): Data source for materialization. Auto-detected from graph type if not specified.
           'staged' materializes from uploaded files (generic graphs). 'extensions' materializes from the extensions OLTP
           database (entity graphs).
+      materialize_embeddings (bool | Unset): Include embedding columns in materialization and build HNSW vector
+          indexes in the graph database. When false (default), embedding columns are NULLed out to save space. Set to true
+          for graphs that need vector search. Default: False.
   """
 
   force: bool | Unset = False
@@ -29,6 +32,7 @@ class MaterializeRequest:
   ignore_errors: bool | Unset = True
   dry_run: bool | Unset = False
   source: None | str | Unset = UNSET
+  materialize_embeddings: bool | Unset = False
 
   def to_dict(self) -> dict[str, Any]:
     force = self.force
@@ -45,6 +49,8 @@ class MaterializeRequest:
     else:
       source = self.source
 
+    materialize_embeddings = self.materialize_embeddings
+
     field_dict: dict[str, Any] = {}
 
     field_dict.update({})
@@ -58,6 +64,8 @@ class MaterializeRequest:
       field_dict["dry_run"] = dry_run
     if source is not UNSET:
       field_dict["source"] = source
+    if materialize_embeddings is not UNSET:
+      field_dict["materialize_embeddings"] = materialize_embeddings
 
     return field_dict
 
@@ -81,12 +89,15 @@ class MaterializeRequest:
 
     source = _parse_source(d.pop("source", UNSET))
 
+    materialize_embeddings = d.pop("materialize_embeddings", UNSET)
+
     materialize_request = cls(
       force=force,
       rebuild=rebuild,
       ignore_errors=ignore_errors,
       dry_run=dry_run,
       source=source,
+      materialize_embeddings=materialize_embeddings,
     )
 
     return materialize_request


### PR DESCRIPTION
## Summary

This PR introduces a new `materialization_embeddings` option to the materialization pipeline, allowing clients to control whether embeddings are materialized as part of a materialization request.

## Key Changes

- **`MaterializationOptions`**: Added a new `materialization_embeddings` boolean field (defaulting to `False`) to the options model, giving users fine-grained control over embedding materialization behavior.
- **`MaterializeRequest`**: Extended the request model with the corresponding `materialization_embeddings` parameter, ensuring it is properly propagated through the request payload.
- **`MaterializationClient`**: Updated the client extension to pass the `materialization_embeddings` option from `MaterializationOptions` into the `MaterializeRequest` construction, wiring the full flow end-to-end.

## Breaking Changes

None. The new field defaults to `False`, preserving existing behavior for all current consumers. This is a purely additive, backwards-compatible change.

## Testing Notes

- Verify that existing materialization requests continue to work without specifying the new option (default `False` behavior).
- Test that setting `materialization_embeddings=True` in `MaterializationOptions` correctly includes the flag in the outgoing `MaterializeRequest` payload.
- Validate the serialized request body against the expected API contract to ensure the new field is properly included when set.

## Infrastructure Considerations

- The backend/API must already support the `materialization_embeddings` field in the materialization endpoint; otherwise, the parameter may be silently ignored or cause validation errors depending on the server's strictness.
- No new dependencies or environment changes are required.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/materialize-embeddings`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>