### PR TITLE
Add JWT token support alongside API keys in GraphQLClient

### DIFF
--- a/robosystems_client/graphql/client.py
+++ b/robosystems_client/graphql/client.py
@@ -64,8 +64,24 @@ class GraphQLClient:
     if headers:
       self._headers.update(headers)
     if token:
-      # Match the existing facade convention: send the token as X-API-Key.
-      self._headers["X-API-Key"] = token
+      # The backend accepts two credential formats, and they go in
+      # DIFFERENT headers — not interchangeable:
+      #
+      #   - Long-lived API keys (``rfs…`` prefix) → ``X-API-Key``.
+      #     Validated against the api_keys table.
+      #   - Short-lived JWTs → ``Authorization: Bearer …``. Validated
+      #     by the JWT middleware.
+      #
+      # Sending a JWT as ``X-API-Key`` (or an API key as Bearer) both
+      # fail with 401 "Invalid API key". Python callers overwhelmingly
+      # pass ``rfs…`` keys since this client targets server/CLI/MCP
+      # use cases, but we keep the routing symmetric with the TS
+      # client so a caller that forwards a JWT (e.g. a backend
+      # proxying a request-scoped token) still works.
+      if token.startswith("rfs"):
+        self._headers["X-API-Key"] = token
+      else:
+        self._headers["Authorization"] = f"Bearer {token}"
 
   def _url_for(self, graph_id: str) -> str:
     if not graph_id:


### PR DESCRIPTION
## Summary

Enhances the `GraphQLClient` to support authentication using both API keys and JWT tokens. The client now intelligently detects the token type and applies the appropriate authorization header format, enabling seamless integration with JWT-based authentication flows.

## Key Accomplishments

- **Dual authentication support**: The GraphQL client now accepts both traditional API keys and JWT tokens for authentication
- **Automatic token type detection**: Implements logic to distinguish between API keys and JWTs, applying the correct `Authorization` header format (`Bearer` for JWTs vs. the existing mechanism for API keys)
- **Backward compatible**: Existing API key-based authentication continues to work without any changes to consumer code

## Changes

- Modified `robosystems_client/graphql/client.py` to:
  - Add JWT token detection and handling logic
  - Set appropriate authorization headers based on the token type
  - Maintain existing API key authentication as the default path

## Breaking Changes

None. This is a backward-compatible enhancement. Existing clients using API keys will continue to function identically.

## Testing Notes

- Verify authentication works correctly when providing a valid JWT token
- Verify authentication continues to work correctly with existing API keys
- Confirm that malformed or expired JWTs are handled gracefully and surface appropriate error messages
- Test edge cases around token format detection to ensure API keys are not misidentified as JWTs and vice versa

## Infrastructure Considerations

- Ensure that backend GraphQL endpoints are configured to accept both API key and JWT-based authorization headers
- JWT token issuance and refresh mechanisms should be in place before relying on JWT authentication in production environments
- Review any token expiration and renewal strategies, as JWTs typically have shorter lifespans than API keys

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `chore/jwt-token-graphql-auth`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>