### PR TITLE
Refactor: Replace 'classification' with 'trait' in GraphQL queries

### DIFF
--- a/robosystems_client/graphql/queries/ledger/__init__.py
+++ b/robosystems_client/graphql/queries/ledger/__init__.py
@@ -137,7 +137,7 @@ query ListLedgerAccounts(
       code
       name
       description
-      classification
+      trait
       subClassification
       balanceType
       parentId
@@ -165,13 +165,13 @@ query GetLedgerAccountTree {
   accountTree {
     totalAccounts
     roots {
-      id code name classification accountType balanceType depth isActive
+      id code name trait accountType balanceType depth isActive
       children {
-        id code name classification accountType balanceType depth isActive
+        id code name trait accountType balanceType depth isActive
         children {
-          id code name classification accountType balanceType depth isActive
+          id code name trait accountType balanceType depth isActive
           children {
-            id code name classification accountType balanceType depth isActive
+            id code name trait accountType balanceType depth isActive
           }
         }
       }
@@ -205,7 +205,7 @@ query GetLedgerAccountRollups(
       reportingElementId
       reportingName
       reportingQname
-      classification
+      trait
       balanceType
       total
       accounts {
@@ -238,7 +238,7 @@ query GetLedgerTrialBalance($startDate: Date, $endDate: Date) {
       accountId
       accountCode
       accountName
-      classification
+      trait
       accountType
       totalDebits
       totalCredits
@@ -270,7 +270,7 @@ query GetLedgerMappedTrialBalance(
       reportingElementId
       qname
       reportingName
-      classification
+      trait
       balanceType
       totalDebits
       totalCredits
@@ -395,7 +395,7 @@ query ListLedgerElements(
   ) {
     elements {
       id code name description qname namespace
-      classification subClassification balanceType periodType
+      trait subClassification balanceType periodType
       isAbstract elementType source taxonomyId parentId depth
       isActive externalId externalSource
     }
@@ -413,7 +413,7 @@ def parse_elements(data: dict[str, Any]) -> dict[str, Any] | None:
 LIST_UNMAPPED_ELEMENTS_QUERY = """
 query ListLedgerUnmappedElements($mappingId: String) {
   unmappedElements(mappingId: $mappingId) {
-    id code name classification balanceType externalSource
+    id code name trait balanceType externalSource
     suggestedTargets { elementId qname name confidence }
   }
 }
@@ -697,7 +697,7 @@ query GetLedgerStatement($reportId: String!, $structureType: String!) {
     reportId structureId structureName structureType unmappedCount
     periods { start end label }
     rows {
-      elementId elementQname elementName classification
+      elementId elementQname elementName trait
       values isSubtotal depth
     }
     validation { passed checks failures warnings }

--- a/robosystems_client/graphql/queries/library/__init__.py
+++ b/robosystems_client/graphql/queries/library/__init__.py
@@ -108,7 +108,7 @@ query ListLibraryElements(
     qname
     namespace
     name
-    classification
+    trait
     statementContext
     derivationRole
     balanceType
@@ -146,7 +146,7 @@ query SearchLibraryElements($query: String!, $source: String, $limit: Int! = 50)
     qname
     namespace
     name
-    classification
+    trait
     statementContext
     derivationRole
     balanceType
@@ -184,7 +184,7 @@ query GetLibraryElement($id: ID, $qname: String) {
     qname
     namespace
     name
-    classification
+    trait
     statementContext
     derivationRole
     balanceType
@@ -272,7 +272,7 @@ query GetLibraryElementArcs($id: ID!) {
       id
       qname
       name
-      classification
+      trait
       statementContext
       derivationRole
       source
@@ -294,7 +294,7 @@ query GetLibraryElementEquivalents($id: ID!) {
       id
       qname
       name
-      classification
+      trait
       statementContext
       derivationRole
       source
@@ -303,7 +303,7 @@ query GetLibraryElementEquivalents($id: ID!) {
       id
       qname
       name
-      classification
+      trait
       statementContext
       derivationRole
       source


### PR DESCRIPTION
## Summary

This PR updates GraphQL queries in the `robosystems_client` package to replace references to `classification` with `trait`, aligning the client queries with an updated GraphQL schema/API.

## Key Accomplishments

- **Ledger queries updated**: Replaced all occurrences of `classification` with `trait` across ledger-related GraphQL query definitions (11 line changes), ensuring the client correctly queries the current API schema.
- **Library queries updated**: Similarly updated library-related GraphQL query definitions (6 line changes) to use `trait` instead of `classification`.
- **Consistent terminology**: Both query modules now use the unified `trait` terminology, maintaining consistency across the entire client query layer.

## Breaking Changes

⚠️ **Yes — this is a breaking change if consumers depend on the previous field names.**

- Any downstream code that references `classification` fields in GraphQL response objects will need to be updated to use `trait` instead.
- This change assumes the backend GraphQL schema has already been updated (or is being updated in tandem) to expose `trait` rather than `classification`. If the backend still serves `classification`, these queries will fail.

## Testing Notes

- Verify that all GraphQL queries in both `ledger` and `library` modules execute successfully against the target API environment.
- Confirm that response parsing and any dependent business logic correctly handle the renamed `trait` field.
- Run integration tests to ensure end-to-end flows (ledger lookups, library queries) return expected results with the updated field name.
- Check for any other references to `classification` elsewhere in the codebase that may also need updating for consistency.

## Infrastructure Considerations

- Ensure the GraphQL API/schema that this client communicates with has been deployed with the `trait` field available before rolling out this client change to production.
- Coordinate deployment ordering: backend schema changes should be live before clients using this updated query set are deployed, to avoid query resolution errors.
- Consider backward compatibility if multiple client versions may be active simultaneously during rollout.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `chore/fix-graqhql-queries`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>