### PR TITLE
Refactor API error handling to unify 422 error response types

### DIFF
--- a/robosystems_client/api/connections/sync_connection.py
+++ b/robosystems_client/api/connections/sync_connection.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...models.sync_connection_request import SyncConnectionRequest
 from ...types import UNSET, Response, Unset
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> Any | ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -100,7 +99,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[Any | ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -116,7 +115,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: SyncConnectionRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[Any | ErrorResponse | OperationEnvelope]:
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
@@ -134,7 +133,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[Any | ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -158,7 +157,7 @@ def sync(
   client: AuthenticatedClient,
   body: SyncConnectionRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> Any | ErrorResponse | OperationEnvelope | None:
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
@@ -176,7 +175,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | ErrorResponse | HTTPValidationError | OperationEnvelope
+      Any | ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -195,7 +194,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: SyncConnectionRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[Any | ErrorResponse | OperationEnvelope]:
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
@@ -213,7 +212,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[Any | ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -235,7 +234,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: SyncConnectionRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> Any | ErrorResponse | OperationEnvelope | None:
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
@@ -253,7 +252,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | ErrorResponse | HTTPValidationError | OperationEnvelope
+      Any | ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_investor/op_create_portfolio_block.py
+++ b/robosystems_client/api/extensions_robo_investor/op_create_portfolio_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_portfolio_block_request import CreatePortfolioBlockRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_portfolio_block_envelope import (
   OperationEnvelopePortfolioBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePortfolioBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePortfolioBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopePortfolioBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreatePortfolioBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]:
   """Create Portfolio Block
 
    Create a portfolio with optional initial positions in a single atomic envelope. Each position
@@ -142,7 +135,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -164,13 +157,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreatePortfolioBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePortfolioBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePortfolioBlockEnvelope | None:
   """Create Portfolio Block
 
    Create a portfolio with optional initial positions in a single atomic envelope. Each position
@@ -195,7 +182,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopePortfolioBlockEnvelope
   """
 
   return sync_detailed(
@@ -212,9 +199,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreatePortfolioBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]:
   """Create Portfolio Block
 
    Create a portfolio with optional initial positions in a single atomic envelope. Each position
@@ -239,7 +224,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -259,13 +244,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreatePortfolioBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePortfolioBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePortfolioBlockEnvelope | None:
   """Create Portfolio Block
 
    Create a portfolio with optional initial positions in a single atomic envelope. Each position
@@ -290,7 +269,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopePortfolioBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_investor/op_create_security.py
+++ b/robosystems_client/api/extensions_robo_investor/op_create_security.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_security_request import CreateSecurityRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_security_response import (
   OperationEnvelopeSecurityResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,48 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError | None
-):
+) -> ErrorResponse | OperationEnvelopeSecurityResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeSecurityResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -94,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeSecurityResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -111,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateSecurityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeSecurityResponse]:
   """Create Security
 
    Register a security (common stock, preferred stock, warrant, convertible note, etc.) owned by this
@@ -138,7 +135,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeSecurityResponse]
   """
 
   kwargs = _get_kwargs(
@@ -160,9 +157,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateSecurityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError | None
-):
+) -> ErrorResponse | OperationEnvelopeSecurityResponse | None:
   """Create Security
 
    Register a security (common stock, preferred stock, warrant, convertible note, etc.) owned by this
@@ -187,7 +182,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
+      ErrorResponse | OperationEnvelopeSecurityResponse
   """
 
   return sync_detailed(
@@ -204,9 +199,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateSecurityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeSecurityResponse]:
   """Create Security
 
    Register a security (common stock, preferred stock, warrant, convertible note, etc.) owned by this
@@ -231,7 +224,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeSecurityResponse]
   """
 
   kwargs = _get_kwargs(
@@ -251,9 +244,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateSecurityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError | None
-):
+) -> ErrorResponse | OperationEnvelopeSecurityResponse | None:
   """Create Security
 
    Register a security (common stock, preferred stock, warrant, convertible note, etc.) owned by this
@@ -278,7 +269,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
+      ErrorResponse | OperationEnvelopeSecurityResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_investor/op_delete_portfolio_block.py
+++ b/robosystems_client/api/extensions_robo_investor/op_delete_portfolio_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_portfolio_block_operation import DeletePortfolioBlockOperation
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_delete_portfolio_block_response import (
   OperationEnvelopeDeletePortfolioBlockResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,13 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeletePortfolioBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeletePortfolioBlockResponse.from_dict(
       response.json()
@@ -57,39 +50,43 @@ def _parse_response(
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -100,12 +97,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeletePortfolioBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -120,12 +112,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeletePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeletePortfolioBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse]:
   """Delete Portfolio Block
 
    Cascade-delete the portfolio plus all of its positions. When active positions exist, the request
@@ -151,7 +138,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeletePortfolioBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -173,13 +160,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeletePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeletePortfolioBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse | None:
   """Delete Portfolio Block
 
    Cascade-delete the portfolio plus all of its positions. When active positions exist, the request
@@ -205,7 +186,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeletePortfolioBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse
   """
 
   return sync_detailed(
@@ -222,12 +203,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeletePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeletePortfolioBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse]:
   """Delete Portfolio Block
 
    Cascade-delete the portfolio plus all of its positions. When active positions exist, the request
@@ -253,7 +229,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeletePortfolioBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -273,13 +249,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeletePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeletePortfolioBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse | None:
   """Delete Portfolio Block
 
    Cascade-delete the portfolio plus all of its positions. When active positions exist, the request
@@ -305,7 +275,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeletePortfolioBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopeDeletePortfolioBlockResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_investor/op_delete_security.py
+++ b/robosystems_client/api/extensions_robo_investor/op_delete_security.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,9 +7,8 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_security_operation import DeleteSecurityOperation
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_delete_result import OperationEnvelopeDeleteResult
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -40,46 +39,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteResult.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -90,9 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -107,9 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Security
 
    Soft-delete the security (`is_active=false`). Historical positions referencing it remain valid.
@@ -128,7 +127,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +149,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Security
 
    Soft-delete the security (`is_active=false`). Historical positions referencing it remain valid.
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return sync_detailed(
@@ -186,9 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Security
 
    Soft-delete the security (`is_active=false`). Historical positions referencing it remain valid.
@@ -207,7 +204,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -227,7 +224,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Security
 
    Soft-delete the security (`is_active=false`). Historical positions referencing it remain valid.
@@ -246,7 +243,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_investor/op_update_portfolio_block.py
+++ b/robosystems_client/api/extensions_robo_investor/op_update_portfolio_block.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_portfolio_block_envelope import (
   OperationEnvelopePortfolioBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...models.update_portfolio_block_operation import UpdatePortfolioBlockOperation
 from ...types import UNSET, Response, Unset
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePortfolioBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePortfolioBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopePortfolioBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdatePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]:
   """Update Portfolio Block
 
    Patch portfolio fields and apply position deltas (`add` / `update` / `dispose`) atomically. Partial
@@ -141,7 +134,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -163,13 +156,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdatePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePortfolioBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePortfolioBlockEnvelope | None:
   """Update Portfolio Block
 
    Patch portfolio fields and apply position deltas (`add` / `update` / `dispose`) atomically. Partial
@@ -193,7 +180,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopePortfolioBlockEnvelope
   """
 
   return sync_detailed(
@@ -210,9 +197,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdatePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]:
   """Update Portfolio Block
 
    Patch portfolio fields and apply position deltas (`add` / `update` / `dispose`) atomically. Partial
@@ -236,7 +221,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopePortfolioBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -256,13 +241,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdatePortfolioBlockOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePortfolioBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePortfolioBlockEnvelope | None:
   """Update Portfolio Block
 
    Patch portfolio fields and apply position deltas (`add` / `update` / `dispose`) atomically. Partial
@@ -286,7 +265,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopePortfolioBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopePortfolioBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_investor/op_update_security.py
+++ b/robosystems_client/api/extensions_robo_investor/op_update_security.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_security_response import (
   OperationEnvelopeSecurityResponse,
 )
-from ...models.operation_error import OperationError
 from ...models.update_security_operation import UpdateSecurityOperation
 from ...types import UNSET, Response, Unset
 
@@ -42,48 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError | None
-):
+) -> ErrorResponse | OperationEnvelopeSecurityResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeSecurityResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -94,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeSecurityResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -111,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeSecurityResponse]:
   """Update Security
 
    Update mutable fields on a security (name, type, subtype, terms, share counts, entity linkage).
@@ -132,7 +129,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeSecurityResponse]
   """
 
   kwargs = _get_kwargs(
@@ -154,9 +151,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError | None
-):
+) -> ErrorResponse | OperationEnvelopeSecurityResponse | None:
   """Update Security
 
    Update mutable fields on a security (name, type, subtype, terms, share counts, entity linkage).
@@ -175,7 +170,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
+      ErrorResponse | OperationEnvelopeSecurityResponse
   """
 
   return sync_detailed(
@@ -192,9 +187,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeSecurityResponse]:
   """Update Security
 
    Update mutable fields on a security (name, type, subtype, terms, share counts, entity linkage).
@@ -213,7 +206,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeSecurityResponse]
   """
 
   kwargs = _get_kwargs(
@@ -233,9 +226,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateSecurityOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError | None
-):
+) -> ErrorResponse | OperationEnvelopeSecurityResponse | None:
   """Update Security
 
    Update mutable fields on a security (name, type, subtype, terms, share counts, entity linkage).
@@ -254,7 +245,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeSecurityResponse | OperationError
+      ErrorResponse | OperationEnvelopeSecurityResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_add_publish_list_members.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_add_publish_list_members.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.add_publish_list_members_operation import AddPublishListMembersOperation
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelopelist_publish_list_member_response import (
   OperationEnvelopelistPublishListMemberResponse,
 )
@@ -42,12 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  ErrorResponse
-  | HTTPValidationError
-  | OperationEnvelopelistPublishListMemberResponse
-  | None
-):
+) -> ErrorResponse | OperationEnvelopelistPublishListMemberResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopelistPublishListMemberResponse.from_dict(
       response.json()
@@ -81,7 +75,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -103,9 +97,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopelistPublishListMemberResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopelistPublishListMemberResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -120,9 +112,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: AddPublishListMembersOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopelistPublishListMemberResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopelistPublishListMemberResponse]:
   """Add Members to Publish List
 
    Add one or more recipient graphs to a publish list. Targets must exist and have the same extension
@@ -141,7 +131,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopelistPublishListMemberResponse]
+      Response[ErrorResponse | OperationEnvelopelistPublishListMemberResponse]
   """
 
   kwargs = _get_kwargs(
@@ -163,12 +153,7 @@ def sync(
   client: AuthenticatedClient,
   body: AddPublishListMembersOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse
-  | HTTPValidationError
-  | OperationEnvelopelistPublishListMemberResponse
-  | None
-):
+) -> ErrorResponse | OperationEnvelopelistPublishListMemberResponse | None:
   """Add Members to Publish List
 
    Add one or more recipient graphs to a publish list. Targets must exist and have the same extension
@@ -187,7 +172,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopelistPublishListMemberResponse
+      ErrorResponse | OperationEnvelopelistPublishListMemberResponse
   """
 
   return sync_detailed(
@@ -204,9 +189,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: AddPublishListMembersOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopelistPublishListMemberResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopelistPublishListMemberResponse]:
   """Add Members to Publish List
 
    Add one or more recipient graphs to a publish list. Targets must exist and have the same extension
@@ -225,7 +208,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopelistPublishListMemberResponse]
+      Response[ErrorResponse | OperationEnvelopelistPublishListMemberResponse]
   """
 
   kwargs = _get_kwargs(
@@ -245,12 +228,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: AddPublishListMembersOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse
-  | HTTPValidationError
-  | OperationEnvelopelistPublishListMemberResponse
-  | None
-):
+) -> ErrorResponse | OperationEnvelopelistPublishListMemberResponse | None:
   """Add Members to Publish List
 
    Add one or more recipient graphs to a publish list. Targets must exist and have the same extension
@@ -269,7 +247,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopelistPublishListMemberResponse
+      ErrorResponse | OperationEnvelopelistPublishListMemberResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_auto_map_elements.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_auto_map_elements.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.auto_map_elements_operation import AutoMapElementsOperation
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: AutoMapElementsOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Auto-Map Elements via AI (async)
 
    Dispatches to the background worker — returns a `pending` envelope immediately. Monitor via SSE at
@@ -136,7 +135,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -158,7 +157,7 @@ def sync(
   client: AuthenticatedClient,
   body: AutoMapElementsOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Auto-Map Elements via AI (async)
 
    Dispatches to the background worker — returns a `pending` envelope immediately. Monitor via SSE at
@@ -185,7 +184,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -202,7 +201,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: AutoMapElementsOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Auto-Map Elements via AI (async)
 
    Dispatches to the background worker — returns a `pending` envelope immediately. Monitor via SSE at
@@ -229,7 +228,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -249,7 +248,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: AutoMapElementsOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Auto-Map Elements via AI (async)
 
    Dispatches to the background worker — returns a `pending` envelope immediately. Monitor via SSE at
@@ -276,7 +275,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_build_fact_grid.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_build_fact_grid.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_view_request import CreateViewRequest
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -129,7 +128,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -151,7 +150,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -171,7 +170,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -188,7 +187,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -208,7 +207,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -228,7 +227,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -248,7 +247,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_close_period.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_close_period.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.close_period_operation import ClosePeriodOperation
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_close_period_response import (
   OperationEnvelopeClosePeriodResponse,
 )
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse | None:
+) -> ErrorResponse | OperationEnvelopeClosePeriodResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeClosePeriodResponse.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeClosePeriodResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -113,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: ClosePeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeClosePeriodResponse]:
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
@@ -140,7 +135,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse]
+      Response[ErrorResponse | OperationEnvelopeClosePeriodResponse]
   """
 
   kwargs = _get_kwargs(
@@ -162,7 +157,7 @@ def sync(
   client: AuthenticatedClient,
   body: ClosePeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse | None:
+) -> ErrorResponse | OperationEnvelopeClosePeriodResponse | None:
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
@@ -187,7 +182,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse
+      ErrorResponse | OperationEnvelopeClosePeriodResponse
   """
 
   return sync_detailed(
@@ -204,9 +199,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: ClosePeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeClosePeriodResponse]:
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
@@ -231,7 +224,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse]
+      Response[ErrorResponse | OperationEnvelopeClosePeriodResponse]
   """
 
   kwargs = _get_kwargs(
@@ -251,7 +244,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: ClosePeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse | None:
+) -> ErrorResponse | OperationEnvelopeClosePeriodResponse | None:
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
@@ -276,7 +269,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeClosePeriodResponse
+      ErrorResponse | OperationEnvelopeClosePeriodResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_agent.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_agent.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_agent_request import CreateAgentRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_ledger_agent_response import (
   OperationEnvelopeLedgerAgentResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeLedgerAgentResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeLedgerAgentResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeLedgerAgentResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]:
   """Create Agent
 
    Create a counterparty record (customer, vendor, employee, etc.). The (source, external_id) pair is a
@@ -143,7 +136,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]
   """
 
   kwargs = _get_kwargs(
@@ -165,13 +158,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeLedgerAgentResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeLedgerAgentResponse | None:
   """Create Agent
 
    Create a counterparty record (customer, vendor, employee, etc.). The (source, external_id) pair is a
@@ -197,7 +184,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
+      ErrorResponse | OperationEnvelopeLedgerAgentResponse
   """
 
   return sync_detailed(
@@ -214,9 +201,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]:
   """Create Agent
 
    Create a counterparty record (customer, vendor, employee, etc.). The (source, external_id) pair is a
@@ -242,7 +227,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]
   """
 
   kwargs = _get_kwargs(
@@ -262,13 +247,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeLedgerAgentResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeLedgerAgentResponse | None:
   """Create Agent
 
    Create a counterparty record (customer, vendor, employee, etc.). The (source, external_id) pair is a
@@ -294,7 +273,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
+      ErrorResponse | OperationEnvelopeLedgerAgentResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_event_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_event_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_event_block_request import CreateEventBlockRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_event_block_envelope import (
   OperationEnvelopeEventBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeEventBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]:
   """Create Event Block
 
    Persist a real-world business event. apply_handlers=False (default): capture-only,
@@ -137,7 +130,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -159,13 +152,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventBlockEnvelope | None:
   """Create Event Block
 
    Persist a real-world business event. apply_handlers=False (default): capture-only,
@@ -185,7 +172,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeEventBlockEnvelope
   """
 
   return sync_detailed(
@@ -202,9 +189,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]:
   """Create Event Block
 
    Persist a real-world business event. apply_handlers=False (default): capture-only,
@@ -224,7 +209,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -244,13 +229,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventBlockEnvelope | None:
   """Create Event Block
 
    Persist a real-world business event. apply_handlers=False (default): capture-only,
@@ -270,7 +249,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeEventBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_event_handler.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_event_handler.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_event_handler_request import CreateEventHandlerRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_event_handler_response import (
   OperationEnvelopeEventHandlerResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventHandlerResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventHandlerResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeEventHandlerResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]:
   """Create Event Handler
 
    Define a rule that fires GL transactions when a matching event block is created with
@@ -151,7 +144,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]
   """
 
   kwargs = _get_kwargs(
@@ -173,13 +166,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventHandlerResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventHandlerResponse | None:
   """Create Event Handler
 
    Define a rule that fires GL transactions when a matching event block is created with
@@ -213,7 +200,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
+      ErrorResponse | OperationEnvelopeEventHandlerResponse
   """
 
   return sync_detailed(
@@ -230,9 +217,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]:
   """Create Event Handler
 
    Define a rule that fires GL transactions when a matching event block is created with
@@ -266,7 +251,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]
   """
 
   kwargs = _get_kwargs(
@@ -286,13 +271,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventHandlerResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventHandlerResponse | None:
   """Create Event Handler
 
    Define a rule that fires GL transactions when a matching event block is created with
@@ -326,7 +305,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
+      ErrorResponse | OperationEnvelopeEventHandlerResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_information_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_information_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -8,11 +8,10 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_legacy_arm import CreateLegacyArm
 from ...models.create_schedule_arm import CreateScheduleArm
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_information_block_envelope import (
   OperationEnvelopeInformationBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -46,52 +45,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeInformationBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeInformationBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeInformationBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -102,9 +99,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -119,9 +114,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateLegacyArm | CreateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]:
   """Create Information Block
 
    Generic Information Block construction entry. `block_type` selects the registered block type;
@@ -147,7 +140,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -169,13 +162,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateLegacyArm | CreateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeInformationBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeInformationBlockEnvelope | None:
   """Create Information Block
 
    Generic Information Block construction entry. `block_type` selects the registered block type;
@@ -201,7 +188,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeInformationBlockEnvelope
   """
 
   return sync_detailed(
@@ -218,9 +205,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateLegacyArm | CreateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]:
   """Create Information Block
 
    Generic Information Block construction entry. `block_type` selects the registered block type;
@@ -246,7 +231,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -266,13 +251,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateLegacyArm | CreateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeInformationBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeInformationBlockEnvelope | None:
   """Create Information Block
 
    Generic Information Block construction entry. `block_type` selects the registered block type;
@@ -298,7 +277,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeInformationBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_mapping_association.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_mapping_association.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -9,11 +9,10 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_mapping_association_operation import (
   CreateMappingAssociationOperation,
 )
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_association_response import (
   OperationEnvelopeAssociationResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -44,52 +43,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeAssociationResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeAssociationResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeAssociationResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -100,9 +97,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeAssociationResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeAssociationResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -117,9 +112,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeAssociationResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeAssociationResponse]:
   """Create Mapping Association
 
    Link a chart-of-accounts element to a US GAAP reporting concept. One mapping edge per call — use
@@ -143,7 +136,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeAssociationResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeAssociationResponse]
   """
 
   kwargs = _get_kwargs(
@@ -165,13 +158,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeAssociationResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeAssociationResponse | None:
   """Create Mapping Association
 
    Link a chart-of-accounts element to a US GAAP reporting concept. One mapping edge per call — use
@@ -195,7 +182,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeAssociationResponse | OperationError
+      ErrorResponse | OperationEnvelopeAssociationResponse
   """
 
   return sync_detailed(
@@ -212,9 +199,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeAssociationResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeAssociationResponse]:
   """Create Mapping Association
 
    Link a chart-of-accounts element to a US GAAP reporting concept. One mapping edge per call — use
@@ -238,7 +223,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeAssociationResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeAssociationResponse]
   """
 
   kwargs = _get_kwargs(
@@ -258,13 +243,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeAssociationResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeAssociationResponse | None:
   """Create Mapping Association
 
    Link a chart-of-accounts element to a US GAAP reporting concept. One mapping edge per call — use
@@ -288,7 +267,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeAssociationResponse | OperationError
+      ErrorResponse | OperationEnvelopeAssociationResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_publish_list.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_publish_list.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_publish_list_request import CreatePublishListRequest
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_publish_list_response import (
   OperationEnvelopePublishListResponse,
 )
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse | None:
+) -> ErrorResponse | OperationEnvelopePublishListResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopePublishListResponse.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopePublishListResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -113,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreatePublishListRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopePublishListResponse]:
   """Create Publish List
 
    Create a publish list (a saved set of recipient graphs). Members are managed separately via
@@ -136,7 +131,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse]
+      Response[ErrorResponse | OperationEnvelopePublishListResponse]
   """
 
   kwargs = _get_kwargs(
@@ -158,7 +153,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreatePublishListRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse | None:
+) -> ErrorResponse | OperationEnvelopePublishListResponse | None:
   """Create Publish List
 
    Create a publish list (a saved set of recipient graphs). Members are managed separately via
@@ -179,7 +174,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
+      ErrorResponse | OperationEnvelopePublishListResponse
   """
 
   return sync_detailed(
@@ -196,9 +191,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreatePublishListRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopePublishListResponse]:
   """Create Publish List
 
    Create a publish list (a saved set of recipient graphs). Members are managed separately via
@@ -219,7 +212,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse]
+      Response[ErrorResponse | OperationEnvelopePublishListResponse]
   """
 
   kwargs = _get_kwargs(
@@ -239,7 +232,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreatePublishListRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse | None:
+) -> ErrorResponse | OperationEnvelopePublishListResponse | None:
   """Create Publish List
 
    Create a publish list (a saved set of recipient graphs). Members are managed separately via
@@ -260,7 +253,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
+      ErrorResponse | OperationEnvelopePublishListResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_report.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_report.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_report_request import CreateReportRequest
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_report_response import OperationEnvelopeReportResponse
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeReportResponse.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """Create Report
 
    Generates report facts from the ledger and marks the report as published.
@@ -141,7 +140,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -163,7 +162,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """Create Report
 
    Generates report facts from the ledger and marks the report as published.
@@ -195,7 +194,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return sync_detailed(
@@ -212,7 +211,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """Create Report
 
    Generates report facts from the ledger and marks the report as published.
@@ -244,7 +243,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -264,7 +263,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """Create Report
 
    Generates report facts from the ledger and marks the report as published.
@@ -296,7 +295,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_create_taxonomy_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_taxonomy_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_taxonomy_block_request import CreateTaxonomyBlockRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_taxonomy_block_envelope import (
   OperationEnvelopeTaxonomyBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeTaxonomyBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeTaxonomyBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]:
   """Create Taxonomy Block
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
@@ -148,7 +141,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -170,13 +163,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeTaxonomyBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope | None:
   """Create Taxonomy Block
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
@@ -207,7 +194,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope
   """
 
   return sync_detailed(
@@ -224,9 +211,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]:
   """Create Taxonomy Block
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
@@ -257,7 +242,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -277,13 +262,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeTaxonomyBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope | None:
   """Create Taxonomy Block
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
@@ -314,7 +293,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_delete_information_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_delete_information_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -8,11 +8,10 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_legacy_arm import DeleteLegacyArm
 from ...models.delete_schedule_arm import DeleteScheduleArm
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_delete_information_block_response import (
   OperationEnvelopeDeleteInformationBlockResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -46,13 +45,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteInformationBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteInformationBlockResponse.from_dict(
       response.json()
@@ -61,39 +54,43 @@ def _parse_response(
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -104,12 +101,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteInformationBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -124,12 +116,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteLegacyArm | DeleteScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteInformationBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse]:
   """Delete Information Block
 
    Generic Information Block deletion entry. Returns a thin confirmation (deleted / structure_id /
@@ -153,7 +140,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteInformationBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -175,13 +162,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteLegacyArm | DeleteScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteInformationBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse | None:
   """Delete Information Block
 
    Generic Information Block deletion entry. Returns a thin confirmation (deleted / structure_id /
@@ -205,7 +186,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteInformationBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse
   """
 
   return sync_detailed(
@@ -222,12 +203,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteLegacyArm | DeleteScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteInformationBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse]:
   """Delete Information Block
 
    Generic Information Block deletion entry. Returns a thin confirmation (deleted / structure_id /
@@ -251,7 +227,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteInformationBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -271,13 +247,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteLegacyArm | DeleteScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteInformationBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse | None:
   """Delete Information Block
 
    Generic Information Block deletion entry. Returns a thin confirmation (deleted / structure_id /
@@ -301,7 +271,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteInformationBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopeDeleteInformationBlockResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_delete_journal_entry.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_delete_journal_entry.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,9 +7,8 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_journal_entry_request import DeleteJournalEntryRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_delete_result import OperationEnvelopeDeleteResult
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -40,46 +39,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteResult.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -90,9 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -107,9 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Journal Entry
 
    Hard-delete a draft journal entry. Posted entries are immutable and must be reversed instead.
@@ -129,7 +128,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -151,7 +150,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Journal Entry
 
    Hard-delete a draft journal entry. Posted entries are immutable and must be reversed instead.
@@ -171,7 +170,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return sync_detailed(
@@ -188,9 +187,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Journal Entry
 
    Hard-delete a draft journal entry. Posted entries are immutable and must be reversed instead.
@@ -210,7 +207,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -230,7 +227,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Journal Entry
 
    Hard-delete a draft journal entry. Posted entries are immutable and must be reversed instead.
@@ -250,7 +247,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteResult | OperationError
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_delete_mapping_association.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_delete_mapping_association.py
@@ -10,7 +10,6 @@ from ...models.delete_mapping_association_operation import (
   DeleteMappingAssociationOperation,
 )
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_delete_result import OperationEnvelopeDeleteResult
 from ...types import UNSET, Response, Unset
 
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteResult.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,7 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -111,7 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Mapping Association
 
    Remove a single CoA → reporting-concept mapping edge. The mapping structure itself remains; only the
@@ -131,7 +130,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -153,7 +152,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Mapping Association
 
    Remove a single CoA → reporting-concept mapping edge. The mapping structure itself remains; only the
@@ -173,7 +172,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return sync_detailed(
@@ -190,7 +189,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Mapping Association
 
    Remove a single CoA → reporting-concept mapping edge. The mapping structure itself remains; only the
@@ -210,7 +209,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -230,7 +229,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteMappingAssociationOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Mapping Association
 
    Remove a single CoA → reporting-concept mapping edge. The mapping structure itself remains; only the
@@ -250,7 +249,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_delete_publish_list.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_delete_publish_list.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_publish_list_operation import DeletePublishListOperation
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_delete_result import OperationEnvelopeDeleteResult
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteResult.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeletePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Publish List
 
    Delete a publish list and its membership rows. Reports previously shared via this list are not
@@ -131,7 +130,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -153,7 +152,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeletePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Publish List
 
    Delete a publish list and its membership rows. Reports previously shared via this list are not
@@ -175,7 +174,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return sync_detailed(
@@ -192,7 +191,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeletePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Publish List
 
    Delete a publish list and its membership rows. Reports previously shared via this list are not
@@ -214,7 +213,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -234,7 +233,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeletePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Publish List
 
    Delete a publish list and its membership rows. Reports previously shared via this list are not
@@ -256,7 +255,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_delete_report.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_delete_report.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_report_operation import DeleteReportOperation
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_delete_result import OperationEnvelopeDeleteResult
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteResult.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Report
 
    Deletes the report definition and all generated facts.
@@ -127,7 +126,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -149,7 +148,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Report
 
    Deletes the report definition and all generated facts.
@@ -167,7 +166,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return sync_detailed(
@@ -184,7 +183,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Delete Report
 
    Deletes the report definition and all generated facts.
@@ -202,7 +201,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -222,7 +221,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Delete Report
 
    Deletes the report definition and all generated facts.
@@ -240,7 +239,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_delete_taxonomy_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_delete_taxonomy_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_taxonomy_block_request import DeleteTaxonomyBlockRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_delete_taxonomy_block_response import (
   OperationEnvelopeDeleteTaxonomyBlockResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,13 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteTaxonomyBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteTaxonomyBlockResponse.from_dict(
       response.json()
@@ -57,39 +50,43 @@ def _parse_response(
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -100,12 +97,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteTaxonomyBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -120,12 +112,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteTaxonomyBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse]:
   """Delete Taxonomy Block
 
    Delete a taxonomy block and return a thin confirmation. `cascade_facts=True` also deletes Fact rows
@@ -151,7 +138,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteTaxonomyBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -173,13 +160,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteTaxonomyBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse | None:
   """Delete Taxonomy Block
 
    Delete a taxonomy block and return a thin confirmation. `cascade_facts=True` also deletes Fact rows
@@ -205,7 +186,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteTaxonomyBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse
   """
 
   return sync_detailed(
@@ -222,12 +203,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteTaxonomyBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse]:
   """Delete Taxonomy Block
 
    Delete a taxonomy block and return a thin confirmation. `cascade_facts=True` also deletes Fact rows
@@ -253,7 +229,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeDeleteTaxonomyBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -273,13 +249,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeDeleteTaxonomyBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse | None:
   """Delete Taxonomy Block
 
    Delete a taxonomy block and return a thin confirmation. `cascade_facts=True` also deletes Fact rows
@@ -305,7 +275,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeDeleteTaxonomyBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopeDeleteTaxonomyBlockResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_evaluate_rules.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_evaluate_rules.py
@@ -1,17 +1,16 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
 from ...models.evaluate_rules_request import EvaluateRulesRequest
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_evaluate_rules_response import (
   OperationEnvelopeEvaluateRulesResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEvaluateRulesResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEvaluateRulesResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeEvaluateRulesResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEvaluateRulesResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEvaluateRulesResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: EvaluateRulesRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEvaluateRulesResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEvaluateRulesResponse]:
   """Evaluate Rules for an Information Block
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
@@ -147,7 +140,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEvaluateRulesResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEvaluateRulesResponse]
   """
 
   kwargs = _get_kwargs(
@@ -169,13 +162,7 @@ def sync(
   client: AuthenticatedClient,
   body: EvaluateRulesRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEvaluateRulesResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEvaluateRulesResponse | None:
   """Evaluate Rules for an Information Block
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
@@ -205,7 +192,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEvaluateRulesResponse | OperationError
+      ErrorResponse | OperationEnvelopeEvaluateRulesResponse
   """
 
   return sync_detailed(
@@ -222,9 +209,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: EvaluateRulesRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEvaluateRulesResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEvaluateRulesResponse]:
   """Evaluate Rules for an Information Block
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
@@ -254,7 +239,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEvaluateRulesResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEvaluateRulesResponse]
   """
 
   kwargs = _get_kwargs(
@@ -274,13 +259,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: EvaluateRulesRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEvaluateRulesResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEvaluateRulesResponse | None:
   """Evaluate Rules for an Information Block
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
@@ -310,7 +289,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEvaluateRulesResponse | OperationError
+      ErrorResponse | OperationEnvelopeEvaluateRulesResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_file_report.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_file_report.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.file_report_request import FileReportRequest
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_report_response import OperationEnvelopeReportResponse
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeReportResponse.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: FileReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """File Report
 
    Transitions the Report's filing_status to 'filed' — locks the package. Allowed from 'draft' or
@@ -135,7 +134,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -157,7 +156,7 @@ def sync(
   client: AuthenticatedClient,
   body: FileReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """File Report
 
    Transitions the Report's filing_status to 'filed' — locks the package. Allowed from 'draft' or
@@ -183,7 +182,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return sync_detailed(
@@ -200,7 +199,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: FileReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """File Report
 
    Transitions the Report's filing_status to 'filed' — locks the package. Allowed from 'draft' or
@@ -226,7 +225,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -246,7 +245,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: FileReportRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """File Report
 
    Transitions the Report's filing_status to 'filed' — locks the package. Allowed from 'draft' or
@@ -272,7 +271,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_financial_statement_analysis.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_financial_statement_analysis.py
@@ -10,7 +10,6 @@ from ...models.error_response import ErrorResponse
 from ...models.financial_statement_analysis_request import (
   FinancialStatementAnalysisRequest,
 )
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelope.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,7 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -111,7 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -133,7 +132,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -155,7 +154,7 @@ def sync(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -177,7 +176,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -194,7 +193,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -216,7 +215,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -236,7 +235,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -258,7 +257,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_initialize_ledger.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_initialize_ledger.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.initialize_ledger_request import InitializeLedgerRequest
 from ...models.operation_envelope_initialize_ledger_response import (
   OperationEnvelopeInitializeLedgerResponse,
@@ -42,9 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeInitializeLedgerResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeInitializeLedgerResponse.from_dict(response.json())
 
@@ -76,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInitializeLedgerResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: InitializeLedgerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInitializeLedgerResponse]:
   """Initialize Ledger
 
    One-time setup: creates the fiscal calendar and seeds periods. Returns 409 if already initialized.
@@ -148,7 +141,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse]
+      Response[ErrorResponse | OperationEnvelopeInitializeLedgerResponse]
   """
 
   kwargs = _get_kwargs(
@@ -170,9 +163,7 @@ def sync(
   client: AuthenticatedClient,
   body: InitializeLedgerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeInitializeLedgerResponse | None:
   """Initialize Ledger
 
    One-time setup: creates the fiscal calendar and seeds periods. Returns 409 if already initialized.
@@ -203,7 +194,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse
+      ErrorResponse | OperationEnvelopeInitializeLedgerResponse
   """
 
   return sync_detailed(
@@ -220,9 +211,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: InitializeLedgerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInitializeLedgerResponse]:
   """Initialize Ledger
 
    One-time setup: creates the fiscal calendar and seeds periods. Returns 409 if already initialized.
@@ -253,7 +242,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse]
+      Response[ErrorResponse | OperationEnvelopeInitializeLedgerResponse]
   """
 
   kwargs = _get_kwargs(
@@ -273,9 +262,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: InitializeLedgerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeInitializeLedgerResponse | None:
   """Initialize Ledger
 
    One-time setup: creates the fiscal calendar and seeds periods. Returns 409 if already initialized.
@@ -306,7 +293,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeInitializeLedgerResponse
+      ErrorResponse | OperationEnvelopeInitializeLedgerResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_link_entity_taxonomy.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_link_entity_taxonomy.py
@@ -1,17 +1,16 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.link_entity_taxonomy_request import LinkEntityTaxonomyRequest
 from ...models.operation_envelope_entity_taxonomy_response import (
   OperationEnvelopeEntityTaxonomyResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEntityTaxonomyResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEntityTaxonomyResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeEntityTaxonomyResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEntityTaxonomyResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEntityTaxonomyResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: LinkEntityTaxonomyRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEntityTaxonomyResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEntityTaxonomyResponse]:
   """Link Entity to Taxonomy
 
    Link the graph's entity to a taxonomy. Idempotent — returns existing linkage if it already exists.
@@ -147,7 +140,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEntityTaxonomyResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEntityTaxonomyResponse]
   """
 
   kwargs = _get_kwargs(
@@ -169,13 +162,7 @@ def sync(
   client: AuthenticatedClient,
   body: LinkEntityTaxonomyRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEntityTaxonomyResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEntityTaxonomyResponse | None:
   """Link Entity to Taxonomy
 
    Link the graph's entity to a taxonomy. Idempotent — returns existing linkage if it already exists.
@@ -205,7 +192,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEntityTaxonomyResponse | OperationError
+      ErrorResponse | OperationEnvelopeEntityTaxonomyResponse
   """
 
   return sync_detailed(
@@ -222,9 +209,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: LinkEntityTaxonomyRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEntityTaxonomyResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEntityTaxonomyResponse]:
   """Link Entity to Taxonomy
 
    Link the graph's entity to a taxonomy. Idempotent — returns existing linkage if it already exists.
@@ -254,7 +239,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEntityTaxonomyResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEntityTaxonomyResponse]
   """
 
   kwargs = _get_kwargs(
@@ -274,13 +259,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: LinkEntityTaxonomyRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEntityTaxonomyResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEntityTaxonomyResponse | None:
   """Link Entity to Taxonomy
 
    Link the graph's entity to a taxonomy. Idempotent — returns existing linkage if it already exists.
@@ -310,7 +289,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEntityTaxonomyResponse | OperationError
+      ErrorResponse | OperationEnvelopeEntityTaxonomyResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_live_financial_statement.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_live_financial_statement.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.live_financial_statement_request import LiveFinancialStatementRequest
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -131,7 +130,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -153,7 +152,7 @@ def sync(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -175,7 +174,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -192,7 +191,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -214,7 +213,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -234,7 +233,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -256,7 +255,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_preview_event_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_preview_event_block.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,11 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_event_block_request import CreateEventBlockRequest
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_preview_event_block_response import (
   OperationEnvelopePreviewEventBlockResponse,
 )
-from ...models.operation_error import OperationError
 from ...types import UNSET, Response, Unset
 
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePreviewEventBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePreviewEventBlockResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopePreviewEventBlockResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,12 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePreviewEventBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePreviewEventBlockResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -118,12 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePreviewEventBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePreviewEventBlockResponse]:
   """Preview Event Block
 
    Dry-run: resolve the matching handler and evaluate the transaction template without writing any
@@ -143,7 +130,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopePreviewEventBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopePreviewEventBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -165,13 +152,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePreviewEventBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePreviewEventBlockResponse | None:
   """Preview Event Block
 
    Dry-run: resolve the matching handler and evaluate the transaction template without writing any
@@ -191,7 +172,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopePreviewEventBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopePreviewEventBlockResponse
   """
 
   return sync_detailed(
@@ -208,12 +189,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePreviewEventBlockResponse
-  | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopePreviewEventBlockResponse]:
   """Preview Event Block
 
    Dry-run: resolve the matching handler and evaluate the transaction template without writing any
@@ -233,7 +209,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopePreviewEventBlockResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopePreviewEventBlockResponse]
   """
 
   kwargs = _get_kwargs(
@@ -253,13 +229,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopePreviewEventBlockResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopePreviewEventBlockResponse | None:
   """Preview Event Block
 
    Dry-run: resolve the matching handler and evaluate the transaction template without writing any
@@ -279,7 +249,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopePreviewEventBlockResponse | OperationError
+      ErrorResponse | OperationEnvelopePreviewEventBlockResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_regenerate_report.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_regenerate_report.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_report_response import OperationEnvelopeReportResponse
 from ...models.regenerate_report_operation import RegenerateReportOperation
 from ...types import UNSET, Response, Unset
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeReportResponse.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: RegenerateReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """Regenerate Report
 
    Re-runs fact generation for an existing Report against the latest ledger state. Pass
@@ -131,7 +130,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -153,7 +152,7 @@ def sync(
   client: AuthenticatedClient,
   body: RegenerateReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """Regenerate Report
 
    Re-runs fact generation for an existing Report against the latest ledger state. Pass
@@ -175,7 +174,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return sync_detailed(
@@ -192,7 +191,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: RegenerateReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """Regenerate Report
 
    Re-runs fact generation for an existing Report against the latest ledger state. Pass
@@ -214,7 +213,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -234,7 +233,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: RegenerateReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """Regenerate Report
 
    Re-runs fact generation for an existing Report against the latest ledger state. Pass
@@ -256,7 +255,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_remove_publish_list_member.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_remove_publish_list_member.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_delete_result import OperationEnvelopeDeleteResult
 from ...models.remove_publish_list_member_operation import (
   RemovePublishListMemberOperation,
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeDeleteResult.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,7 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -111,7 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: RemovePublishListMemberOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Remove Member from Publish List
 
    Remove a single recipient from a publish list.
@@ -129,7 +128,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -151,7 +150,7 @@ def sync(
   client: AuthenticatedClient,
   body: RemovePublishListMemberOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Remove Member from Publish List
 
    Remove a single recipient from a publish list.
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return sync_detailed(
@@ -186,7 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: RemovePublishListMemberOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]:
+) -> Response[ErrorResponse | OperationEnvelopeDeleteResult]:
   """Remove Member from Publish List
 
    Remove a single recipient from a publish list.
@@ -204,7 +203,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult]
+      Response[ErrorResponse | OperationEnvelopeDeleteResult]
   """
 
   kwargs = _get_kwargs(
@@ -224,7 +223,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: RemovePublishListMemberOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult | None:
+) -> ErrorResponse | OperationEnvelopeDeleteResult | None:
   """Remove Member from Publish List
 
    Remove a single recipient from a publish list.
@@ -242,7 +241,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeDeleteResult
+      ErrorResponse | OperationEnvelopeDeleteResult
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_reopen_period.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_reopen_period.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_fiscal_calendar_response import (
   OperationEnvelopeFiscalCalendarResponse,
 )
@@ -42,9 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeFiscalCalendarResponse.from_dict(response.json())
 
@@ -76,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: ReopenPeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
@@ -137,7 +130,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse]
+      Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]
   """
 
   kwargs = _get_kwargs(
@@ -159,9 +152,7 @@ def sync(
   client: AuthenticatedClient,
   body: ReopenPeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
@@ -181,7 +172,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
+      ErrorResponse | OperationEnvelopeFiscalCalendarResponse
   """
 
   return sync_detailed(
@@ -198,9 +189,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: ReopenPeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
@@ -220,7 +209,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse]
+      Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]
   """
 
   kwargs = _get_kwargs(
@@ -240,9 +229,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: ReopenPeriodOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
@@ -262,7 +249,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
+      ErrorResponse | OperationEnvelopeFiscalCalendarResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_set_close_target.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_set_close_target.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_fiscal_calendar_response import (
   OperationEnvelopeFiscalCalendarResponse,
 )
@@ -42,9 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeFiscalCalendarResponse.from_dict(response.json())
 
@@ -76,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: SetCloseTargetOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   """Set Close Target
 
    Set the user-controlled goal period for closing (`close_target`). Format: YYYY-MM. Distinct from
@@ -138,7 +131,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse]
+      Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]
   """
 
   kwargs = _get_kwargs(
@@ -160,9 +153,7 @@ def sync(
   client: AuthenticatedClient,
   body: SetCloseTargetOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   """Set Close Target
 
    Set the user-controlled goal period for closing (`close_target`). Format: YYYY-MM. Distinct from
@@ -183,7 +174,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
+      ErrorResponse | OperationEnvelopeFiscalCalendarResponse
   """
 
   return sync_detailed(
@@ -200,9 +191,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: SetCloseTargetOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   """Set Close Target
 
    Set the user-controlled goal period for closing (`close_target`). Format: YYYY-MM. Distinct from
@@ -223,7 +212,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse]
+      Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]
   """
 
   kwargs = _get_kwargs(
@@ -243,9 +232,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: SetCloseTargetOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse | None
-):
+) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   """Set Close Target
 
    Set the user-controlled goal period for closing (`close_target`). Format: YYYY-MM. Distinct from
@@ -266,7 +253,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeFiscalCalendarResponse
+      ErrorResponse | OperationEnvelopeFiscalCalendarResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_share_report.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_share_report.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_share_report_response import (
   OperationEnvelopeShareReportResponse,
 )
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeShareReportResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeShareReportResponse.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeShareReportResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -113,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: ShareReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeShareReportResponse]:
   """Share Report
 
    Pushes a published report to every member of the target publish list. Each share is an independent
@@ -136,7 +131,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse]
+      Response[ErrorResponse | OperationEnvelopeShareReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -158,7 +153,7 @@ def sync(
   client: AuthenticatedClient,
   body: ShareReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeShareReportResponse | None:
   """Share Report
 
    Pushes a published report to every member of the target publish list. Each share is an independent
@@ -179,7 +174,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse
+      ErrorResponse | OperationEnvelopeShareReportResponse
   """
 
   return sync_detailed(
@@ -196,9 +191,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: ShareReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeShareReportResponse]:
   """Share Report
 
    Pushes a published report to every member of the target publish list. Each share is an independent
@@ -219,7 +212,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse]
+      Response[ErrorResponse | OperationEnvelopeShareReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -239,7 +232,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: ShareReportOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeShareReportResponse | None:
   """Share Report
 
    Pushes a published report to every member of the target publish list. Each share is an independent
@@ -260,7 +253,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeShareReportResponse
+      ErrorResponse | OperationEnvelopeShareReportResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_transition_filing_status.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_transition_filing_status.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_report_response import OperationEnvelopeReportResponse
 from ...models.transition_filing_status_request import TransitionFilingStatusRequest
 from ...types import UNSET, Response, Unset
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeReportResponse.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: TransitionFilingStatusRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """Transition Filing Status
 
    Move a Report along the non-file legs of the filing lifecycle (draft ↔ under_review, filed →
@@ -134,7 +133,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -156,7 +155,7 @@ def sync(
   client: AuthenticatedClient,
   body: TransitionFilingStatusRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """Transition Filing Status
 
    Move a Report along the non-file legs of the filing lifecycle (draft ↔ under_review, filed →
@@ -181,7 +180,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return sync_detailed(
@@ -198,7 +197,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: TransitionFilingStatusRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]:
+) -> Response[ErrorResponse | OperationEnvelopeReportResponse]:
   """Transition Filing Status
 
    Move a Report along the non-file legs of the filing lifecycle (draft ↔ under_review, filed →
@@ -223,7 +222,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse]
+      Response[ErrorResponse | OperationEnvelopeReportResponse]
   """
 
   kwargs = _get_kwargs(
@@ -243,7 +242,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: TransitionFilingStatusRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse | None:
+) -> ErrorResponse | OperationEnvelopeReportResponse | None:
   """Transition Filing Status
 
    Move a Report along the non-file legs of the filing lifecycle (draft ↔ under_review, filed →
@@ -268,7 +267,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeReportResponse
+      ErrorResponse | OperationEnvelopeReportResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_agent.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_agent.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_ledger_agent_response import (
   OperationEnvelopeLedgerAgentResponse,
 )
-from ...models.operation_error import OperationError
 from ...models.update_agent_request import UpdateAgentRequest
 from ...types import UNSET, Response, Unset
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeLedgerAgentResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeLedgerAgentResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeLedgerAgentResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]:
   """Update Agent
 
    Patch counterparty fields. Only supplied fields are updated. Set is_active=false to deactivate
@@ -138,7 +131,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]
   """
 
   kwargs = _get_kwargs(
@@ -160,13 +153,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeLedgerAgentResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeLedgerAgentResponse | None:
   """Update Agent
 
    Patch counterparty fields. Only supplied fields are updated. Set is_active=false to deactivate
@@ -187,7 +174,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
+      ErrorResponse | OperationEnvelopeLedgerAgentResponse
   """
 
   return sync_detailed(
@@ -204,9 +191,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]:
   """Update Agent
 
    Patch counterparty fields. Only supplied fields are updated. Set is_active=false to deactivate
@@ -227,7 +212,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeLedgerAgentResponse]
   """
 
   kwargs = _get_kwargs(
@@ -247,13 +232,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateAgentRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeLedgerAgentResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeLedgerAgentResponse | None:
   """Update Agent
 
    Patch counterparty fields. Only supplied fields are updated. Set is_active=false to deactivate
@@ -274,7 +253,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeLedgerAgentResponse | OperationError
+      ErrorResponse | OperationEnvelopeLedgerAgentResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_entity.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_entity.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_ledger_entity_response import (
   OperationEnvelopeLedgerEntityResponse,
 )
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse | None:
+) -> ErrorResponse | OperationEnvelopeLedgerEntityResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeLedgerEntityResponse.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerEntityResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -113,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateEntityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerEntityResponse]:
   """Update Entity
 
    Update the graph's primary entity. Only provided (non-null) fields are updated. The graph is
@@ -140,7 +135,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse]
+      Response[ErrorResponse | OperationEnvelopeLedgerEntityResponse]
   """
 
   kwargs = _get_kwargs(
@@ -162,7 +157,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateEntityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse | None:
+) -> ErrorResponse | OperationEnvelopeLedgerEntityResponse | None:
   """Update Entity
 
    Update the graph's primary entity. Only provided (non-null) fields are updated. The graph is
@@ -187,7 +182,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse
+      ErrorResponse | OperationEnvelopeLedgerEntityResponse
   """
 
   return sync_detailed(
@@ -204,9 +199,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateEntityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopeLedgerEntityResponse]:
   """Update Entity
 
    Update the graph's primary entity. Only provided (non-null) fields are updated. The graph is
@@ -231,7 +224,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse]
+      Response[ErrorResponse | OperationEnvelopeLedgerEntityResponse]
   """
 
   kwargs = _get_kwargs(
@@ -251,7 +244,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateEntityRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse | None:
+) -> ErrorResponse | OperationEnvelopeLedgerEntityResponse | None:
   """Update Entity
 
    Update the graph's primary entity. Only provided (non-null) fields are updated. The graph is
@@ -276,7 +269,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopeLedgerEntityResponse
+      ErrorResponse | OperationEnvelopeLedgerEntityResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_event_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_event_block.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_event_block_envelope import (
   OperationEnvelopeEventBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...models.update_event_block_request import UpdateEventBlockRequest
 from ...types import UNSET, Response, Unset
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeEventBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]:
   """Update Event Block
 
    Apply a status transition (captured → committed | voided) and/or field corrections (description,
@@ -143,7 +136,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -165,13 +158,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventBlockEnvelope | None:
   """Update Event Block
 
    Apply a status transition (captured → committed | voided) and/or field corrections (description,
@@ -197,7 +184,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeEventBlockEnvelope
   """
 
   return sync_detailed(
@@ -214,9 +201,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]:
   """Update Event Block
 
    Apply a status transition (captured → committed | voided) and/or field corrections (description,
@@ -242,7 +227,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -262,13 +247,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateEventBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventBlockEnvelope | None:
   """Update Event Block
 
    Apply a status transition (captured → committed | voided) and/or field corrections (description,
@@ -294,7 +273,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeEventBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_event_handler.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_event_handler.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_event_handler_response import (
   OperationEnvelopeEventHandlerResponse,
 )
-from ...models.operation_error import OperationError
 from ...models.update_event_handler_request import UpdateEventHandlerRequest
 from ...types import UNSET, Response, Unset
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventHandlerResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventHandlerResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeEventHandlerResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]:
   """Update Event Handler
 
    Patch an event handler's match criteria, template, priority, or active state. Pass approve=true to
@@ -142,7 +135,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]
   """
 
   kwargs = _get_kwargs(
@@ -164,13 +157,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventHandlerResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventHandlerResponse | None:
   """Update Event Handler
 
    Patch an event handler's match criteria, template, priority, or active state. Pass approve=true to
@@ -195,7 +182,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
+      ErrorResponse | OperationEnvelopeEventHandlerResponse
   """
 
   return sync_detailed(
@@ -212,9 +199,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]:
   """Update Event Handler
 
    Patch an event handler's match criteria, template, priority, or active state. Pass approve=true to
@@ -239,7 +224,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeEventHandlerResponse]
   """
 
   kwargs = _get_kwargs(
@@ -259,13 +244,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateEventHandlerRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeEventHandlerResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeEventHandlerResponse | None:
   """Update Event Handler
 
    Patch an event handler's match criteria, template, priority, or active state. Pass approve=true to
@@ -290,7 +269,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeEventHandlerResponse | OperationError
+      ErrorResponse | OperationEnvelopeEventHandlerResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_information_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_information_block.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_information_block_envelope import (
   OperationEnvelopeInformationBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...models.update_legacy_arm import UpdateLegacyArm
 from ...models.update_schedule_arm import UpdateScheduleArm
 from ...types import UNSET, Response, Unset
@@ -46,52 +45,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeInformationBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeInformationBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeInformationBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -102,9 +99,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -119,9 +114,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateLegacyArm | UpdateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]:
   """Update Information Block
 
    Generic Information Block update entry. Dispatches by `block_type` to the registered mutation
@@ -146,7 +139,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -168,13 +161,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateLegacyArm | UpdateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeInformationBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeInformationBlockEnvelope | None:
   """Update Information Block
 
    Generic Information Block update entry. Dispatches by `block_type` to the registered mutation
@@ -199,7 +186,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeInformationBlockEnvelope
   """
 
   return sync_detailed(
@@ -216,9 +203,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateLegacyArm | UpdateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]:
   """Update Information Block
 
    Generic Information Block update entry. Dispatches by `block_type` to the registered mutation
@@ -243,7 +228,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeInformationBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -263,13 +248,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateLegacyArm | UpdateScheduleArm,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeInformationBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeInformationBlockEnvelope | None:
   """Update Information Block
 
    Generic Information Block update entry. Dispatches by `block_type` to the registered mutation
@@ -294,7 +273,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeInformationBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeInformationBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_journal_entry.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_journal_entry.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_journal_entry_response import (
   OperationEnvelopeJournalEntryResponse,
 )
-from ...models.operation_error import OperationError
 from ...models.update_journal_entry_request import UpdateJournalEntryRequest
 from ...types import UNSET, Response, Unset
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeJournalEntryResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeJournalEntryResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeJournalEntryResponse.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeJournalEntryResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeJournalEntryResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeJournalEntryResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeJournalEntryResponse]:
   """Update Journal Entry
 
    Update a draft journal entry. Posted entries are immutable and must be corrected via `create-event-
@@ -144,7 +137,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeJournalEntryResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeJournalEntryResponse]
   """
 
   kwargs = _get_kwargs(
@@ -166,13 +159,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeJournalEntryResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeJournalEntryResponse | None:
   """Update Journal Entry
 
    Update a draft journal entry. Posted entries are immutable and must be corrected via `create-event-
@@ -199,7 +186,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeJournalEntryResponse | OperationError
+      ErrorResponse | OperationEnvelopeJournalEntryResponse
   """
 
   return sync_detailed(
@@ -216,9 +203,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeJournalEntryResponse | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeJournalEntryResponse]:
   """Update Journal Entry
 
    Update a draft journal entry. Posted entries are immutable and must be corrected via `create-event-
@@ -245,7 +230,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeJournalEntryResponse | OperationError]
+      Response[ErrorResponse | OperationEnvelopeJournalEntryResponse]
   """
 
   kwargs = _get_kwargs(
@@ -265,13 +250,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateJournalEntryRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeJournalEntryResponse
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeJournalEntryResponse | None:
   """Update Journal Entry
 
    Update a draft journal entry. Posted entries are immutable and must be corrected via `create-event-
@@ -298,7 +277,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeJournalEntryResponse | OperationError
+      ErrorResponse | OperationEnvelopeJournalEntryResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_publish_list.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_publish_list.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope_publish_list_response import (
   OperationEnvelopePublishListResponse,
 )
@@ -42,7 +41,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse | None:
+) -> ErrorResponse | OperationEnvelopePublishListResponse | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopePublishListResponse.from_dict(response.json())
 
@@ -74,7 +73,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -96,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopePublishListResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -113,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdatePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopePublishListResponse]:
   """Update Publish List
 
    Updates the publish list's `name` and/or `description`. Membership is managed via add/remove-member
@@ -134,7 +129,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse]
+      Response[ErrorResponse | OperationEnvelopePublishListResponse]
   """
 
   kwargs = _get_kwargs(
@@ -156,7 +151,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdatePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse | None:
+) -> ErrorResponse | OperationEnvelopePublishListResponse | None:
   """Update Publish List
 
    Updates the publish list's `name` and/or `description`. Membership is managed via add/remove-member
@@ -175,7 +170,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
+      ErrorResponse | OperationEnvelopePublishListResponse
   """
 
   return sync_detailed(
@@ -192,9 +187,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdatePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
-]:
+) -> Response[ErrorResponse | OperationEnvelopePublishListResponse]:
   """Update Publish List
 
    Updates the publish list's `name` and/or `description`. Membership is managed via add/remove-member
@@ -213,7 +206,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse]
+      Response[ErrorResponse | OperationEnvelopePublishListResponse]
   """
 
   kwargs = _get_kwargs(
@@ -233,7 +226,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdatePublishListOperation,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse | None:
+) -> ErrorResponse | OperationEnvelopePublishListResponse | None:
   """Update Publish List
 
    Updates the publish list's `name` and/or `description`. Membership is managed via add/remove-member
@@ -252,7 +245,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelopePublishListResponse
+      ErrorResponse | OperationEnvelopePublishListResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/op_update_taxonomy_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_update_taxonomy_block.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.http_validation_error import HTTPValidationError
+from ...models.error_response import ErrorResponse
 from ...models.operation_envelope_taxonomy_block_envelope import (
   OperationEnvelopeTaxonomyBlockEnvelope,
 )
-from ...models.operation_error import OperationError
 from ...models.update_taxonomy_block_request import UpdateTaxonomyBlockRequest
 from ...types import UNSET, Response, Unset
 
@@ -42,52 +41,50 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeTaxonomyBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelopeTaxonomyBlockEnvelope.from_dict(response.json())
 
     return response_200
 
   if response.status_code == 400:
-    response_400 = OperationError.from_dict(response.json())
+    response_400 = ErrorResponse.from_dict(response.json())
 
     return response_400
 
   if response.status_code == 401:
-    response_401 = cast(Any, None)
+    response_401 = ErrorResponse.from_dict(response.json())
+
     return response_401
 
   if response.status_code == 403:
-    response_403 = cast(Any, None)
+    response_403 = ErrorResponse.from_dict(response.json())
+
     return response_403
 
   if response.status_code == 404:
-    response_404 = OperationError.from_dict(response.json())
+    response_404 = ErrorResponse.from_dict(response.json())
 
     return response_404
 
   if response.status_code == 409:
-    response_409 = OperationError.from_dict(response.json())
+    response_409 = ErrorResponse.from_dict(response.json())
 
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
   if response.status_code == 429:
-    response_429 = cast(Any, None)
+    response_429 = ErrorResponse.from_dict(response.json())
+
     return response_429
 
   if response.status_code == 500:
-    response_500 = cast(Any, None)
+    response_500 = ErrorResponse.from_dict(response.json())
+
     return response_500
 
   if client.raise_on_unexpected_status:
@@ -98,9 +95,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -115,9 +110,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: UpdateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]:
   """Update Taxonomy Block
 
    Incrementally mutate a taxonomy block via typed delta lists (elements/structures/associations/rules
@@ -143,7 +136,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -165,13 +158,7 @@ def sync(
   client: AuthenticatedClient,
   body: UpdateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeTaxonomyBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope | None:
   """Update Taxonomy Block
 
    Incrementally mutate a taxonomy block via typed delta lists (elements/structures/associations/rules
@@ -197,7 +184,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope
   """
 
   return sync_detailed(
@@ -214,9 +201,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: UpdateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[
-  Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
-]:
+) -> Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]:
   """Update Taxonomy Block
 
    Incrementally mutate a taxonomy block via typed delta lists (elements/structures/associations/rules
@@ -242,7 +227,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError]
+      Response[ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -262,13 +247,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: UpdateTaxonomyBlockRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> (
-  Any
-  | HTTPValidationError
-  | OperationEnvelopeTaxonomyBlockEnvelope
-  | OperationError
-  | None
-):
+) -> ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope | None:
   """Update Taxonomy Block
 
    Incrementally mutate a taxonomy block via typed delta lists (elements/structures/associations/rules
@@ -294,7 +273,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | HTTPValidationError | OperationEnvelopeTaxonomyBlockEnvelope | OperationError
+      ErrorResponse | OperationEnvelopeTaxonomyBlockEnvelope
   """
 
   return (

--- a/robosystems_client/api/graph_operations/op_change_tier.py
+++ b/robosystems_client/api/graph_operations/op_change_tier.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.change_tier_op import ChangeTierOp
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: ChangeTierOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Change Tier
 
    Async EBS migration (3-5 min). Valid tiers: `ladybug-standard`, `ladybug-large`, `ladybug-xlarge`.
@@ -128,7 +127,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +149,7 @@ def sync(
   client: AuthenticatedClient,
   body: ChangeTierOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Change Tier
 
    Async EBS migration (3-5 min). Valid tiers: `ladybug-standard`, `ladybug-large`, `ladybug-xlarge`.
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -186,7 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: ChangeTierOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Change Tier
 
    Async EBS migration (3-5 min). Valid tiers: `ladybug-standard`, `ladybug-large`, `ladybug-xlarge`.
@@ -205,7 +204,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -225,7 +224,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: ChangeTierOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Change Tier
 
    Async EBS migration (3-5 min). Valid tiers: `ladybug-standard`, `ladybug-large`, `ladybug-xlarge`.
@@ -244,7 +243,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/graph_operations/op_create_backup.py
+++ b/robosystems_client/api/graph_operations/op_create_backup.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backup_create_request import BackupCreateRequest
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: BackupCreateRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Create Backup
 
    Not allowed on shared repositories. Only `full_dump` format supported. Retention capped at tier
@@ -128,7 +127,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +149,7 @@ def sync(
   client: AuthenticatedClient,
   body: BackupCreateRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Create Backup
 
    Not allowed on shared repositories. Only `full_dump` format supported. Retention capped at tier
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -186,7 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: BackupCreateRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Create Backup
 
    Not allowed on shared repositories. Only `full_dump` format supported. Retention capped at tier
@@ -205,7 +204,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -225,7 +224,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: BackupCreateRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Create Backup
 
    Not allowed on shared repositories. Only `full_dump` format supported. Retention capped at tier
@@ -244,7 +243,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/graph_operations/op_create_subgraph.py
+++ b/robosystems_client/api/graph_operations/op_create_subgraph.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_subgraph_request import CreateSubgraphRequest
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateSubgraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Create Subgraph
 
    Set `fork_parent=true` to clone parent graph data into the new subgraph (async, returns a pending
@@ -128,7 +127,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +149,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateSubgraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Create Subgraph
 
    Set `fork_parent=true` to clone parent graph data into the new subgraph (async, returns a pending
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -186,7 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateSubgraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Create Subgraph
 
    Set `fork_parent=true` to clone parent graph data into the new subgraph (async, returns a pending
@@ -205,7 +204,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -225,7 +224,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateSubgraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Create Subgraph
 
    Set `fork_parent=true` to clone parent graph data into the new subgraph (async, returns a pending
@@ -244,7 +243,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/graph_operations/op_delete_graph.py
+++ b/robosystems_client/api/graph_operations/op_delete_graph.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_graph_op import DeleteGraphOp
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteGraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Delete Graph
 
    Permanently destroys a user graph and cancels its subscription. Two modes via the `at_period_end`
@@ -145,7 +144,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -167,7 +166,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteGraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Delete Graph
 
    Permanently destroys a user graph and cancels its subscription. Two modes via the `at_period_end`
@@ -203,7 +202,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -220,7 +219,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteGraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Delete Graph
 
    Permanently destroys a user graph and cancels its subscription. Two modes via the `at_period_end`
@@ -256,7 +255,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -276,7 +275,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteGraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Delete Graph
 
    Permanently destroys a user graph and cancels its subscription. Two modes via the `at_period_end`
@@ -312,7 +311,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/graph_operations/op_delete_subgraph.py
+++ b/robosystems_client/api/graph_operations/op_delete_subgraph.py
@@ -8,7 +8,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_subgraph_op import DeleteSubgraphOp
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 200:
     response_200 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: DeleteSubgraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Delete Subgraph
 
    Set `backup_first=true` to create a safety backup before deletion. Requires admin role on the parent
@@ -128,7 +127,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +149,7 @@ def sync(
   client: AuthenticatedClient,
   body: DeleteSubgraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Delete Subgraph
 
    Set `backup_first=true` to create a safety backup before deletion. Requires admin role on the parent
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -186,7 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: DeleteSubgraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Delete Subgraph
 
    Set `backup_first=true` to create a safety backup before deletion. Requires admin role on the parent
@@ -205,7 +204,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -225,7 +224,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: DeleteSubgraphOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Delete Subgraph
 
    Set `backup_first=true` to create a safety backup before deletion. Requires admin role on the parent
@@ -244,7 +243,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/graph_operations/op_materialize.py
+++ b/robosystems_client/api/graph_operations/op_materialize.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.materialize_op import MaterializeOp
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: MaterializeOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Materialize Graph
 
    Rebuilds LadybugDB from staging tables (file uploads) or extensions OLTP data. Set `dry_run=true` to
@@ -128,7 +127,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +149,7 @@ def sync(
   client: AuthenticatedClient,
   body: MaterializeOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Materialize Graph
 
    Rebuilds LadybugDB from staging tables (file uploads) or extensions OLTP data. Set `dry_run=true` to
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -186,7 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: MaterializeOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Materialize Graph
 
    Rebuilds LadybugDB from staging tables (file uploads) or extensions OLTP data. Set `dry_run=true` to
@@ -205,7 +204,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -225,7 +224,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: MaterializeOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Materialize Graph
 
    Rebuilds LadybugDB from staging tables (file uploads) or extensions OLTP data. Set `dry_run=true` to
@@ -244,7 +243,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/graph_operations/op_restore_backup.py
+++ b/robosystems_client/api/graph_operations/op_restore_backup.py
@@ -7,7 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...models.restore_backup_op import RestoreBackupOp
 from ...types import UNSET, Response, Unset
@@ -40,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -109,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: RestoreBackupOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Restore Backup
 
    Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
@@ -128,7 +127,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +149,7 @@ def sync(
   client: AuthenticatedClient,
   body: RestoreBackupOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Restore Backup
 
    Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
@@ -169,7 +168,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -186,7 +185,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: RestoreBackupOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelope]:
   """Restore Backup
 
    Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
@@ -205,7 +204,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -225,7 +224,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: RestoreBackupOp,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelope | None:
   """Restore Backup
 
    Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
@@ -244,7 +243,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | HTTPValidationError | OperationEnvelope
+      ErrorResponse | OperationEnvelope
   """
 
   return (

--- a/robosystems_client/api/graphs/create_graph.py
+++ b/robosystems_client/api/graphs/create_graph.py
@@ -7,7 +7,6 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_graph_request import CreateGraphRequest
 from ...models.error_response import ErrorResponse
-from ...models.http_validation_error import HTTPValidationError
 from ...models.operation_envelope import OperationEnvelope
 from ...types import UNSET, Response, Unset
 
@@ -36,7 +35,7 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> Any | ErrorResponse | OperationEnvelope | None:
   if response.status_code == 202:
     response_202 = OperationEnvelope.from_dict(response.json())
 
@@ -72,7 +71,7 @@ def _parse_response(
     return response_409
 
   if response.status_code == 422:
-    response_422 = HTTPValidationError.from_dict(response.json())
+    response_422 = ErrorResponse.from_dict(response.json())
 
     return response_422
 
@@ -94,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[Any | ErrorResponse | OperationEnvelope]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -108,7 +107,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateGraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[Any | ErrorResponse | OperationEnvelope]:
   """Create New Graph Database
 
    Creates a graph asynchronously. Returns an `OperationEnvelope` with `operation_id` for SSE progress
@@ -129,7 +128,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[Any | ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -149,7 +148,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateGraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> Any | ErrorResponse | OperationEnvelope | None:
   """Create New Graph Database
 
    Creates a graph asynchronously. Returns an `OperationEnvelope` with `operation_id` for SSE progress
@@ -170,7 +169,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | ErrorResponse | HTTPValidationError | OperationEnvelope
+      Any | ErrorResponse | OperationEnvelope
   """
 
   return sync_detailed(
@@ -185,7 +184,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateGraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]:
+) -> Response[Any | ErrorResponse | OperationEnvelope]:
   """Create New Graph Database
 
    Creates a graph asynchronously. Returns an `OperationEnvelope` with `operation_id` for SSE progress
@@ -206,7 +205,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | ErrorResponse | HTTPValidationError | OperationEnvelope]
+      Response[Any | ErrorResponse | OperationEnvelope]
   """
 
   kwargs = _get_kwargs(
@@ -224,7 +223,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateGraphRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Any | ErrorResponse | HTTPValidationError | OperationEnvelope | None:
+) -> Any | ErrorResponse | OperationEnvelope | None:
   """Create New Graph Database
 
    Creates a graph asynchronously. Returns an `OperationEnvelope` with `operation_id` for SSE progress
@@ -245,7 +244,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | ErrorResponse | HTTPValidationError | OperationEnvelope
+      Any | ErrorResponse | OperationEnvelope
   """
 
   return (


### PR DESCRIPTION
## Summary

Refactors error handling across 54 API operation modules in the `robosystems_client` to standardize how HTTP error responses (particularly 422 Unprocessable Entity) are processed and returned. This change unifies the response type handling pattern across all API operations in the client library.

## Key Accomplishments

- **Unified error response handling**: Standardized the pattern for handling API error responses across all operation modules, eliminating inconsistencies in how errors (especially 422 responses) were parsed and returned.
- **Reduced code complexity**: Simplified error handling logic across all affected modules, as evidenced by the net reduction in lines of code across the board (most files show more deletions than additions).
- **Comprehensive coverage**: Applied the fix consistently across all API surface areas:
  - **Connections** (`sync_connection.py`)
  - **Robo Investor extensions** (CRUD operations for portfolio blocks and securities)
  - **Robo Ledger extensions** (30+ operations covering agents, event blocks, event handlers, information blocks, taxonomy blocks, journal entries, publish lists, reports, mapping associations, periods, and more)
  - **Graph operations** (tier changes, backups, subgraphs, deletions, materialization, restoration)
  - **Graph creation** (`create_graph.py`)

## Breaking Changes

- **Potential breaking change**: Consumers of this client library that explicitly handle or type-check error response objects may need to be updated if the response type for error cases (e.g., 422) has changed. Any code that relies on the previous error response structure should be reviewed and adjusted accordingly.

## Testing Notes

- Verify that all API operations correctly return the unified error response type when the server responds with 422 and other error status codes.
- Validate that successful response paths (2xx) remain unaffected by the refactor.
- Test edge cases around validation errors to ensure error details/messages are properly propagated through the new unified response type.
- Integration tests against live or mocked API endpoints should confirm that deserialization of error responses works correctly across all affected operations.

## Infrastructure Considerations

- This is a client-side library change only; no server-side or infrastructure modifications are required.
- Any CI/CD pipelines running client integration tests should be monitored for regressions after this change is merged.
- Downstream services or applications consuming this client library should be tested for compatibility with the updated error response types before upgrading.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `chore/422-error-resp-fix`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>