### PR TITLE
Add event action types and integrate into event block models

### DIFF
--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -58,6 +58,9 @@ from .create_checkout_request_resource_config import CreateCheckoutRequestResour
 from .create_connection_request import CreateConnectionRequest
 from .create_connection_request_provider import CreateConnectionRequestProvider
 from .create_event_block_request import CreateEventBlockRequest
+from .create_event_block_request_event_action_type_0 import (
+  CreateEventBlockRequestEventActionType0,
+)
 from .create_event_block_request_event_category import (
   CreateEventBlockRequestEventCategory,
 )
@@ -161,6 +164,7 @@ from .evaluate_rules_request import EvaluateRulesRequest
 from .evaluate_rules_response import EvaluateRulesResponse
 from .evaluate_rules_response_summary import EvaluateRulesResponseSummary
 from .event_block_envelope import EventBlockEnvelope
+from .event_block_envelope_event_action_type_0 import EventBlockEnvelopeEventActionType0
 from .event_block_envelope_metadata import EventBlockEnvelopeMetadata
 from .event_handler_response import EventHandlerResponse
 from .event_handler_response_match_metadata_expression_type_0 import (
@@ -596,6 +600,9 @@ from .update_agent_request_metadata_patch import UpdateAgentRequestMetadataPatch
 from .update_api_key_request import UpdateAPIKeyRequest
 from .update_entity_request import UpdateEntityRequest
 from .update_event_block_request import UpdateEventBlockRequest
+from .update_event_block_request_event_action_type_0 import (
+  UpdateEventBlockRequestEventActionType0,
+)
 from .update_event_block_request_metadata_patch import (
   UpdateEventBlockRequestMetadataPatch,
 )
@@ -694,6 +701,7 @@ __all__ = (
   "CreateConnectionRequest",
   "CreateConnectionRequestProvider",
   "CreateEventBlockRequest",
+  "CreateEventBlockRequestEventActionType0",
   "CreateEventBlockRequestEventCategory",
   "CreateEventBlockRequestEventClass",
   "CreateEventBlockRequestMetadata",
@@ -781,6 +789,7 @@ __all__ = (
   "EvaluateRulesResponse",
   "EvaluateRulesResponseSummary",
   "EventBlockEnvelope",
+  "EventBlockEnvelopeEventActionType0",
   "EventBlockEnvelopeMetadata",
   "EventHandlerResponse",
   "EventHandlerResponseMatchMetadataExpressionType0",
@@ -1080,6 +1089,7 @@ __all__ = (
   "UpdateAPIKeyRequest",
   "UpdateEntityRequest",
   "UpdateEventBlockRequest",
+  "UpdateEventBlockRequestEventActionType0",
   "UpdateEventBlockRequestMetadataPatch",
   "UpdateEventBlockRequestTransitionToType0",
   "UpdateEventHandlerRequest",

--- a/robosystems_client/models/create_event_block_request.py
+++ b/robosystems_client/models/create_event_block_request.py
@@ -8,6 +8,9 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..models.create_event_block_request_event_action_type_0 import (
+  CreateEventBlockRequestEventActionType0,
+)
 from ..models.create_event_block_request_event_category import (
   CreateEventBlockRequestEventCategory,
 )
@@ -43,6 +46,10 @@ class CreateEventBlockRequest:
       event_class (CreateEventBlockRequestEventClass | Unset): REA event class. 'economic' events change resources and
           drive GL postings; 'support' events are audit-trail / value-chain primitives (typically captured with
           apply_handlers=False). Default: CreateEventBlockRequestEventClass.ECONOMIC.
+      event_action (CreateEventBlockRequestEventActionType0 | None | Unset): Canonical action verb refining
+          `event_category`. Disambiguates concepts ERPs collapse: `transferAllRights` (ownership transfer, no physical
+          movement) vs `transferCustody` (physical only, no rights transfer) — load-bearing for consignment, drop-
+          shipping, marketplace settlement, escrow. Optional; null is valid for legacy events and during adapter rollout.
       agent_id (None | str | Unset): ID of the counterparty agent (customer, vendor, employee, lender) involved in the
           event. `null` for internal-only events.
       resource_type (CreateEventBlockRequestResourceTypeType0 | None | Unset): REA resource kind being exchanged. One
@@ -78,6 +85,7 @@ class CreateEventBlockRequest:
   event_class: CreateEventBlockRequestEventClass | Unset = (
     CreateEventBlockRequestEventClass.ECONOMIC
   )
+  event_action: CreateEventBlockRequestEventActionType0 | None | Unset = UNSET
   agent_id: None | str | Unset = UNSET
   resource_type: CreateEventBlockRequestResourceTypeType0 | None | Unset = UNSET
   resource_element_id: None | str | Unset = UNSET
@@ -106,6 +114,14 @@ class CreateEventBlockRequest:
     event_class: str | Unset = UNSET
     if not isinstance(self.event_class, Unset):
       event_class = self.event_class.value
+
+    event_action: None | str | Unset
+    if isinstance(self.event_action, Unset):
+      event_action = UNSET
+    elif isinstance(self.event_action, CreateEventBlockRequestEventActionType0):
+      event_action = self.event_action.value
+    else:
+      event_action = self.event_action
 
     agent_id: None | str | Unset
     if isinstance(self.agent_id, Unset):
@@ -195,6 +211,8 @@ class CreateEventBlockRequest:
     )
     if event_class is not UNSET:
       field_dict["event_class"] = event_class
+    if event_action is not UNSET:
+      field_dict["event_action"] = event_action
     if agent_id is not UNSET:
       field_dict["agent_id"] = agent_id
     if resource_type is not UNSET:
@@ -247,6 +265,25 @@ class CreateEventBlockRequest:
       event_class = UNSET
     else:
       event_class = CreateEventBlockRequestEventClass(_event_class)
+
+    def _parse_event_action(
+      data: object,
+    ) -> CreateEventBlockRequestEventActionType0 | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, str):
+          raise TypeError()
+        event_action_type_0 = CreateEventBlockRequestEventActionType0(data)
+
+        return event_action_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(CreateEventBlockRequestEventActionType0 | None | Unset, data)
+
+    event_action = _parse_event_action(d.pop("event_action", UNSET))
 
     def _parse_agent_id(data: object) -> None | str | Unset:
       if data is None:
@@ -381,6 +418,7 @@ class CreateEventBlockRequest:
       occurred_at=occurred_at,
       source=source,
       event_class=event_class,
+      event_action=event_action,
       agent_id=agent_id,
       resource_type=resource_type,
       resource_element_id=resource_element_id,

--- a/robosystems_client/models/create_event_block_request_event_action_type_0.py
+++ b/robosystems_client/models/create_event_block_request_event_action_type_0.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class CreateEventBlockRequestEventActionType0(str, Enum):
+  ACCEPT = "accept"
+  CITE = "cite"
+  COMBINE = "combine"
+  CONSUME = "consume"
+  COPY = "copy"
+  DELIVERSERVICE = "deliverService"
+  DROPOFF = "dropoff"
+  LOWER = "lower"
+  MODIFY = "modify"
+  MOVE = "move"
+  PICKUP = "pickup"
+  PRODUCE = "produce"
+  RAISE = "raise"
+  SEPARATE = "separate"
+  TRANSFER = "transfer"
+  TRANSFERALLRIGHTS = "transferAllRights"
+  TRANSFERCUSTODY = "transferCustody"
+  USE = "use"
+  WORK = "work"
+
+  def __str__(self) -> str:
+    return str(self.value)

--- a/robosystems_client/models/event_block_envelope.py
+++ b/robosystems_client/models/event_block_envelope.py
@@ -8,6 +8,9 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..models.event_block_envelope_event_action_type_0 import (
+  EventBlockEnvelopeEventActionType0,
+)
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -55,6 +58,8 @@ class EventBlockEnvelope:
           amount (int | None | Unset): Economic value in **cents** of `currency`, signed (inflows positive, outflows
               negative). `null` for non-economic events.
           description (None | str | Unset): Free-text human-readable summary.
+          event_action (EventBlockEnvelopeEventActionType0 | None | Unset): Canonical action verb refining
+              `event_category`. Null when the source adapter or capture path didn't supply one.
           agent_id (None | str | Unset): Counterparty agent ID, when the event involves one.
           resource_type (None | str | Unset): REA resource kind being exchanged (`goods`, `services`, `money`, `right`,
               `obligation`, `information`, `labor`).
@@ -86,6 +91,7 @@ class EventBlockEnvelope:
   external_url: None | str | Unset = UNSET
   amount: int | None | Unset = UNSET
   description: None | str | Unset = UNSET
+  event_action: EventBlockEnvelopeEventActionType0 | None | Unset = UNSET
   agent_id: None | str | Unset = UNSET
   resource_type: None | str | Unset = UNSET
   resource_element_id: None | str | Unset = UNSET
@@ -151,6 +157,14 @@ class EventBlockEnvelope:
       description = UNSET
     else:
       description = self.description
+
+    event_action: None | str | Unset
+    if isinstance(self.event_action, Unset):
+      event_action = UNSET
+    elif isinstance(self.event_action, EventBlockEnvelopeEventActionType0):
+      event_action = self.event_action.value
+    else:
+      event_action = self.event_action
 
     agent_id: None | str | Unset
     if isinstance(self.agent_id, Unset):
@@ -222,6 +236,8 @@ class EventBlockEnvelope:
       field_dict["amount"] = amount
     if description is not UNSET:
       field_dict["description"] = description
+    if event_action is not UNSET:
+      field_dict["event_action"] = event_action
     if agent_id is not UNSET:
       field_dict["agent_id"] = agent_id
     if resource_type is not UNSET:
@@ -321,6 +337,25 @@ class EventBlockEnvelope:
 
     description = _parse_description(d.pop("description", UNSET))
 
+    def _parse_event_action(
+      data: object,
+    ) -> EventBlockEnvelopeEventActionType0 | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, str):
+          raise TypeError()
+        event_action_type_0 = EventBlockEnvelopeEventActionType0(data)
+
+        return event_action_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(EventBlockEnvelopeEventActionType0 | None | Unset, data)
+
+    event_action = _parse_event_action(d.pop("event_action", UNSET))
+
     def _parse_agent_id(data: object) -> None | str | Unset:
       if data is None:
         return data
@@ -410,6 +445,7 @@ class EventBlockEnvelope:
       external_url=external_url,
       amount=amount,
       description=description,
+      event_action=event_action,
       agent_id=agent_id,
       resource_type=resource_type,
       resource_element_id=resource_element_id,

--- a/robosystems_client/models/event_block_envelope_event_action_type_0.py
+++ b/robosystems_client/models/event_block_envelope_event_action_type_0.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class EventBlockEnvelopeEventActionType0(str, Enum):
+  ACCEPT = "accept"
+  CITE = "cite"
+  COMBINE = "combine"
+  CONSUME = "consume"
+  COPY = "copy"
+  DELIVERSERVICE = "deliverService"
+  DROPOFF = "dropoff"
+  LOWER = "lower"
+  MODIFY = "modify"
+  MOVE = "move"
+  PICKUP = "pickup"
+  PRODUCE = "produce"
+  RAISE = "raise"
+  SEPARATE = "separate"
+  TRANSFER = "transfer"
+  TRANSFERALLRIGHTS = "transferAllRights"
+  TRANSFERCUSTODY = "transferCustody"
+  USE = "use"
+  WORK = "work"
+
+  def __str__(self) -> str:
+    return str(self.value)

--- a/robosystems_client/models/update_event_block_request.py
+++ b/robosystems_client/models/update_event_block_request.py
@@ -8,6 +8,9 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..models.update_event_block_request_event_action_type_0 import (
+  UpdateEventBlockRequestEventActionType0,
+)
 from ..models.update_event_block_request_transition_to_type_0 import (
   UpdateEventBlockRequestTransitionToType0,
 )
@@ -43,6 +46,9 @@ class UpdateEventBlockRequest:
               an event was captured against the wrong period.
           metadata_patch (UpdateEventBlockRequestMetadataPatch | Unset): Key-value pairs merged into existing metadata
               (additive patch, not replace).
+          event_action (None | Unset | UpdateEventBlockRequestEventActionType0): Set or correct the canonical action verb.
+              Unset = unchanged. Useful when an adapter improvement makes a previously-NULL verb fillable, or when
+              reclassifying after the fact.
           obligated_by_event_id (None | str | Unset): Set/update the forward-materialization link.
           discharges_event_id (None | str | Unset): Set/update the settlement link.
   """
@@ -53,6 +59,7 @@ class UpdateEventBlockRequest:
   description: None | str | Unset = UNSET
   effective_at: datetime.datetime | None | Unset = UNSET
   metadata_patch: UpdateEventBlockRequestMetadataPatch | Unset = UNSET
+  event_action: None | Unset | UpdateEventBlockRequestEventActionType0 = UNSET
   obligated_by_event_id: None | str | Unset = UNSET
   discharges_event_id: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -92,6 +99,14 @@ class UpdateEventBlockRequest:
     if not isinstance(self.metadata_patch, Unset):
       metadata_patch = self.metadata_patch.to_dict()
 
+    event_action: None | str | Unset
+    if isinstance(self.event_action, Unset):
+      event_action = UNSET
+    elif isinstance(self.event_action, UpdateEventBlockRequestEventActionType0):
+      event_action = self.event_action.value
+    else:
+      event_action = self.event_action
+
     obligated_by_event_id: None | str | Unset
     if isinstance(self.obligated_by_event_id, Unset):
       obligated_by_event_id = UNSET
@@ -121,6 +136,8 @@ class UpdateEventBlockRequest:
       field_dict["effective_at"] = effective_at
     if metadata_patch is not UNSET:
       field_dict["metadata_patch"] = metadata_patch
+    if event_action is not UNSET:
+      field_dict["event_action"] = event_action
     if obligated_by_event_id is not UNSET:
       field_dict["obligated_by_event_id"] = obligated_by_event_id
     if discharges_event_id is not UNSET:
@@ -198,6 +215,25 @@ class UpdateEventBlockRequest:
     else:
       metadata_patch = UpdateEventBlockRequestMetadataPatch.from_dict(_metadata_patch)
 
+    def _parse_event_action(
+      data: object,
+    ) -> None | Unset | UpdateEventBlockRequestEventActionType0:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, str):
+          raise TypeError()
+        event_action_type_0 = UpdateEventBlockRequestEventActionType0(data)
+
+        return event_action_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(None | Unset | UpdateEventBlockRequestEventActionType0, data)
+
+    event_action = _parse_event_action(d.pop("event_action", UNSET))
+
     def _parse_obligated_by_event_id(data: object) -> None | str | Unset:
       if data is None:
         return data
@@ -227,6 +263,7 @@ class UpdateEventBlockRequest:
       description=description,
       effective_at=effective_at,
       metadata_patch=metadata_patch,
+      event_action=event_action,
       obligated_by_event_id=obligated_by_event_id,
       discharges_event_id=discharges_event_id,
     )

--- a/robosystems_client/models/update_event_block_request_event_action_type_0.py
+++ b/robosystems_client/models/update_event_block_request_event_action_type_0.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class UpdateEventBlockRequestEventActionType0(str, Enum):
+  ACCEPT = "accept"
+  CITE = "cite"
+  COMBINE = "combine"
+  CONSUME = "consume"
+  COPY = "copy"
+  DELIVERSERVICE = "deliverService"
+  DROPOFF = "dropoff"
+  LOWER = "lower"
+  MODIFY = "modify"
+  MOVE = "move"
+  PICKUP = "pickup"
+  PRODUCE = "produce"
+  RAISE = "raise"
+  SEPARATE = "separate"
+  TRANSFER = "transfer"
+  TRANSFERALLRIGHTS = "transferAllRights"
+  TRANSFERCUSTODY = "transferCustody"
+  USE = "use"
+  WORK = "work"
+
+  def __str__(self) -> str:
+    return str(self.value)


### PR DESCRIPTION
## Summary

Introduces `event_action_type` support across the event block model layer in the `robosystems_client`. This change adds new type definitions and integrates them into the create, update, and envelope models for event blocks.

## Key Accomplishments

- **New type models**: Added three new `event_action_type_0` model classes for `CreateEventBlockRequest`, `UpdateEventBlockRequest`, and `EventBlockEnvelope`, providing structured type definitions for event actions.
- **Model integration**: Updated existing `CreateEventBlockRequest`, `UpdateEventBlockRequest`, and `EventBlockEnvelope` models to incorporate the new `event_action_type` field, enabling event blocks to carry action type metadata.
- **Module exports**: Updated `models/__init__.py` to export all new model classes, ensuring they are accessible throughout the client library.

## Changes Breakdown

| Area | Change |
|------|--------|
| `CreateEventBlockRequest` | Added `event_action_type` field + new type model |
| `UpdateEventBlockRequest` | Added `event_action_type` field + new type model |
| `EventBlockEnvelope` | Added `event_action_type` field + new type model |
| `models/__init__.py` | Registered new model exports |

## Breaking Changes

- **Potentially breaking for consumers**: If any downstream code performs strict schema validation or exhaustive field checks on `CreateEventBlockRequest`, `UpdateEventBlockRequest`, or `EventBlockEnvelope`, the addition of the new `event_action_type` field may require updates. However, since the field is additive, most standard usage patterns should remain unaffected.

## Testing Notes

- Verify that event block creation, update, and retrieval flows correctly serialize and deserialize the new `event_action_type` field.
- Confirm that the new type models (`*_event_action_type_0`) properly handle expected values and edge cases (e.g., `None`/`Unset` states).
- Validate backward compatibility — existing event blocks without an `event_action_type` should continue to work without errors.

## Infrastructure Considerations

- This is a client-side model change; ensure that the corresponding API/backend already supports the `event_action_type` field before deploying consumers that depend on it.
- Auto-generated client code (if applicable) should be kept in sync with the upstream API schema to avoid drift.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/add-event-action`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>