### PR TITLE
chore(sdk): regenerate from latest OpenAPI spec

### DIFF
--- a/robosystems_client/api/extensions_robo_ledger/op_create_taxonomy_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_create_taxonomy_block.py
@@ -115,8 +115,8 @@ def sync_detailed(
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
   elements, associations, and rules. Dispatches by `taxonomy_type` — `chart_of_accounts` (declarative
-  tenant CoA) is live; `reporting_extension` / `custom_ontology` / `reporting_standard` land in later
-  sub-phases.
+  tenant CoA) is supported; `reporting_extension` / `custom_ontology` / `reporting_standard` are not
+  yet implemented.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -168,8 +168,8 @@ def sync(
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
   elements, associations, and rules. Dispatches by `taxonomy_type` — `chart_of_accounts` (declarative
-  tenant CoA) is live; `reporting_extension` / `custom_ontology` / `reporting_standard` land in later
-  sub-phases.
+  tenant CoA) is supported; `reporting_extension` / `custom_ontology` / `reporting_standard` are not
+  yet implemented.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -216,8 +216,8 @@ async def asyncio_detailed(
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
   elements, associations, and rules. Dispatches by `taxonomy_type` — `chart_of_accounts` (declarative
-  tenant CoA) is live; `reporting_extension` / `custom_ontology` / `reporting_standard` land in later
-  sub-phases.
+  tenant CoA) is supported; `reporting_extension` / `custom_ontology` / `reporting_standard` are not
+  yet implemented.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -267,8 +267,8 @@ async def asyncio(
 
    Create a taxonomy block atomically: one envelope carrying the taxonomy row plus its structures,
   elements, associations, and rules. Dispatches by `taxonomy_type` — `chart_of_accounts` (declarative
-  tenant CoA) is live; `reporting_extension` / `custom_ontology` / `reporting_standard` land in later
-  sub-phases.
+  tenant CoA) is supported; `reporting_extension` / `custom_ontology` / `reporting_standard` are not
+  yet implemented.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.

--- a/robosystems_client/api/extensions_robo_ledger/op_evaluate_rules.py
+++ b/robosystems_client/api/extensions_robo_ledger/op_evaluate_rules.py
@@ -115,8 +115,8 @@ def sync_detailed(
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
   structure's atoms), binds $Variable references to in-scope facts via qname lookup, writes one
-  VerificationResult row per rule, and returns the results plus a status-keyed summary. Phase delta.3
-  — decoding mode, 5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
+  VerificationResult row per rule, and returns the results plus a status-keyed summary. Decoding mode,
+  5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -167,8 +167,8 @@ def sync(
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
   structure's atoms), binds $Variable references to in-scope facts via qname lookup, writes one
-  VerificationResult row per rule, and returns the results plus a status-keyed summary. Phase delta.3
-  — decoding mode, 5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
+  VerificationResult row per rule, and returns the results plus a status-keyed summary. Decoding mode,
+  5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -214,8 +214,8 @@ async def asyncio_detailed(
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
   structure's atoms), binds $Variable references to in-scope facts via qname lookup, writes one
-  VerificationResult row per rule, and returns the results plus a status-keyed summary. Phase delta.3
-  — decoding mode, 5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
+  VerificationResult row per rule, and returns the results plus a status-keyed summary. Decoding mode,
+  5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -264,8 +264,8 @@ async def asyncio(
 
    Runs every rule targeting the given structure (plus element- and association-scoped rules for the
   structure's atoms), binds $Variable references to in-scope facts via qname lookup, writes one
-  VerificationResult row per rule, and returns the results plus a status-keyed summary. Phase delta.3
-  — decoding mode, 5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
+  VerificationResult row per rule, and returns the results plus a status-keyed summary. Decoding mode,
+  5 patterns (EqualTo, RollUp, RollForward, Exists, CoExists).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.

--- a/robosystems_client/api/graph_operations/op_change_reporting_style.py
+++ b/robosystems_client/api/graph_operations/op_change_reporting_style.py
@@ -111,9 +111,9 @@ def sync_detailed(
 ) -> Response[ErrorResponse | OperationEnvelope]:
   """Change Reporting Style
 
-   Switches the graph's Reporting Style (Phase 2 of §3.2). Synchronous: validates the target Style has
-  a complete composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports
-  are unaffected; new reports use the new Style. Idempotent on the same id.
+   Switches the graph's Reporting Style. Synchronous: validates the target Style has a complete
+  composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports are
+  unaffected; new reports use the new Style. Idempotent on the same id.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -121,8 +121,7 @@ def sync_detailed(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ChangeReportingStyleOp): Body for the change-reporting-style operation (Phase 2 of
-          §3.2).
+      body (ChangeReportingStyleOp): Body for the change-reporting-style operation.
 
           Switches the graph to a different Reporting Style. The target Style
           must be a library- or customer-authored Structure with
@@ -162,9 +161,9 @@ def sync(
 ) -> ErrorResponse | OperationEnvelope | None:
   """Change Reporting Style
 
-   Switches the graph's Reporting Style (Phase 2 of §3.2). Synchronous: validates the target Style has
-  a complete composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports
-  are unaffected; new reports use the new Style. Idempotent on the same id.
+   Switches the graph's Reporting Style. Synchronous: validates the target Style has a complete
+  composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports are
+  unaffected; new reports use the new Style. Idempotent on the same id.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -172,8 +171,7 @@ def sync(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ChangeReportingStyleOp): Body for the change-reporting-style operation (Phase 2 of
-          §3.2).
+      body (ChangeReportingStyleOp): Body for the change-reporting-style operation.
 
           Switches the graph to a different Reporting Style. The target Style
           must be a library- or customer-authored Structure with
@@ -208,9 +206,9 @@ async def asyncio_detailed(
 ) -> Response[ErrorResponse | OperationEnvelope]:
   """Change Reporting Style
 
-   Switches the graph's Reporting Style (Phase 2 of §3.2). Synchronous: validates the target Style has
-  a complete composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports
-  are unaffected; new reports use the new Style. Idempotent on the same id.
+   Switches the graph's Reporting Style. Synchronous: validates the target Style has a complete
+  composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports are
+  unaffected; new reports use the new Style. Idempotent on the same id.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -218,8 +216,7 @@ async def asyncio_detailed(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ChangeReportingStyleOp): Body for the change-reporting-style operation (Phase 2 of
-          §3.2).
+      body (ChangeReportingStyleOp): Body for the change-reporting-style operation.
 
           Switches the graph to a different Reporting Style. The target Style
           must be a library- or customer-authored Structure with
@@ -257,9 +254,9 @@ async def asyncio(
 ) -> ErrorResponse | OperationEnvelope | None:
   """Change Reporting Style
 
-   Switches the graph's Reporting Style (Phase 2 of §3.2). Synchronous: validates the target Style has
-  a complete composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports
-  are unaffected; new reports use the new Style. Idempotent on the same id.
+   Switches the graph's Reporting Style. Synchronous: validates the target Style has a complete
+  composition in the tenant schema, then updates `graphs.reporting_style_id`. Filed Reports are
+  unaffected; new reports use the new Style. Idempotent on the same id.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -267,8 +264,7 @@ async def asyncio(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ChangeReportingStyleOp): Body for the change-reporting-style operation (Phase 2 of
-          §3.2).
+      body (ChangeReportingStyleOp): Body for the change-reporting-style operation.
 
           Switches the graph to a different Reporting Style. The target Style
           must be a library- or customer-authored Structure with

--- a/robosystems_client/models/change_reporting_style_op.py
+++ b/robosystems_client/models/change_reporting_style_op.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="ChangeReportingStyleOp")
 
 @_attrs_define
 class ChangeReportingStyleOp:
-  """Body for the change-reporting-style operation (Phase 2 of §3.2).
+  """Body for the change-reporting-style operation.
 
   Switches the graph to a different Reporting Style. The target Style
   must be a library- or customer-authored Structure with

--- a/robosystems_client/models/close_period_response.py
+++ b/robosystems_client/models/close_period_response.py
@@ -30,7 +30,7 @@ class ClosePeriodResponse:
           False.
       rule_summary (ClosePeriodResponseRuleSummaryType0 | None | Unset): Aggregated rule-eval outcome across every
           schedule Structure with facts in the closed period — keys: pass/fail/error/skipped. None when no schedules had
-          facts in the period (§3.8 auto-run on close).
+          facts in the period (auto-run on close).
       evaluated_structure_ids (list[str] | Unset): ids of schedule Structures whose rules were evaluated during the
           close. Pairs with rule_summary.
   """

--- a/robosystems_client/models/list_subgraphs_response.py
+++ b/robosystems_client/models/list_subgraphs_response.py
@@ -23,7 +23,7 @@ class ListSubgraphsResponse:
       parent_graph_id (str): Parent graph identifier
       parent_graph_name (str): Parent graph name
       parent_graph_tier (str): Parent graph tier
-      subgraphs_enabled (bool): Whether subgraphs are enabled for this tier (requires LadybugDB Large/XLarge)
+      subgraphs_enabled (bool): Whether subgraphs are enabled for this tier (requires Large/XLarge tier)
       subgraph_count (int): Total number of subgraphs
       subgraphs (list[SubgraphSummary]): List of subgraphs
       max_subgraphs (int | None | Unset): Maximum allowed subgraphs for this tier (None = unlimited)

--- a/robosystems_client/models/rollforward_mechanics.py
+++ b/robosystems_client/models/rollforward_mechanics.py
@@ -22,18 +22,17 @@ T = TypeVar("T", bound="RollforwardMechanics")
 class RollforwardMechanics:
   """Filter-based attribution mechanics for ``block_type='rollforward'``.
 
-  Implements Tier 2 of the rollforward attribution design
-  (``information-block.md`` §4.5). Each block decomposes one BS
-  source element's period delta into a list of flow concepts via
-  declared :class:`AttributionFilter` predicates. The renderer
-  evaluates the filters against ledger LineItems at envelope-build
-  time, emits one attributed fact per filter per period, and arbitrates
-  any residual against the default change tag (Tier 1 fallback).
+  Filter-based attribution: each block decomposes one BS source
+  element's period delta into a list of flow concepts via declared
+  :class:`AttributionFilter` predicates. The renderer evaluates the
+  filters against ledger LineItems at envelope-build time, emits one
+  attributed fact per filter per period, and arbitrates any residual
+  against the default change tag fallback.
 
   Reads directly from the typed ``structures.artifact_mechanics`` JSONB
   column. ``attribution_filters`` rides as nested JSON; the predicate
-  union widens as new predicate shapes ship (Phase 2 MVP carries only
-  ``line_item_metadata_field``).
+  union widens as new predicate shapes are added — currently only
+  ``line_item_metadata_field`` is carried.
 
       Attributes:
           bs_source_element_id (str): Element id of the balance-sheet source whose period delta this block decomposes.
@@ -41,10 +40,10 @@ class RollforwardMechanics:
           bs_source_qname (str): QName of the BS source element (e.g. ``mini:CashAndCashEquivalents``). Round-tripped for
               caller convenience; ``bs_source_element_id`` is authoritative.
           kind (Literal['rollforward'] | Unset):  Default: 'rollforward'.
-          default_change_tag_element_id (None | str | Unset): Element id of the Tier 1 default change tag — the fallback
-              flow concept that receives any residual (Δ BS − Σ filter matches). Null when no default is declared; behavior on
+          default_change_tag_element_id (None | str | Unset): Element id of the default change tag — the fallback flow
+              concept that receives any residual (Δ BS − Σ filter matches). Null when no default is declared; behavior on
               residual then follows ``validation_mode``.
-          default_change_tag_qname (None | str | Unset): QName of the Tier 1 default change tag (e.g. ``rs-
+          default_change_tag_qname (None | str | Unset): QName of the default change tag (e.g. ``rs-
               gaap:IncreaseDecreaseInCashAndCashEquivalents``). Round-tripped for caller convenience and operator-readable
               envelopes; ``default_change_tag_element_id`` is authoritative. Null iff ``default_change_tag_element_id`` is
               null.

--- a/robosystems_client/models/taxonomy_block_rule.py
+++ b/robosystems_client/models/taxonomy_block_rule.py
@@ -17,8 +17,7 @@ class TaxonomyBlockRule:
 
   Exactly one of ``rule_pattern`` (arithmetic) or ``rule_check_kind``
   (model-structure) is non-null per row, enforced by the
-  ``check_rule_pattern_kind_xor`` DB constraint. See
-  information-block.md §5.2.2.
+  ``check_rule_pattern_kind_xor`` DB constraint.
 
       Attributes:
           id (str):

--- a/robosystems_client/models/taxonomy_block_rule_request.py
+++ b/robosystems_client/models/taxonomy_block_rule_request.py
@@ -43,8 +43,7 @@ class TaxonomyBlockRuleRequest:
   ``LeafHasClassification``, ``LibraryOriginImmutability``,
   ``UniqueQNameInTaxonomy``) are system-managed — they're auto-emitted
   by :func:`emit_auto_rules` at taxonomy-block creation time and
-  populate ``rules.rule_check_kind`` instead of ``rule_pattern``. See
-  information-block.md §5.2.2 for the axis split.
+  populate ``rules.rule_check_kind`` instead of ``rule_pattern``.
 
       Attributes:
           name (str): Rule identifier, unique within envelope.

--- a/robosystems_client/models/verification_category_summary.py
+++ b/robosystems_client/models/verification_category_summary.py
@@ -16,8 +16,8 @@ class VerificationCategorySummary:
   """Pass/fail/skip counts for one ``rule_category`` within a block's
   verification results.
 
-  Drives the per-category accordions in the Verification Results panel
-  (financial-viewer §7.12). ``category`` is the rule's ``rule_category``
+  Drives the per-category accordions in the Verification Results panel.
+  ``category`` is the rule's ``rule_category``
   (one of the cm:VerificationRule subclasses), resolved by joining each
   result to its Rule.
 

--- a/robosystems_client/models/verification_summary.py
+++ b/robosystems_client/models/verification_summary.py
@@ -20,7 +20,7 @@ class VerificationSummary:
   """Server-computed aggregate of a block's ``verification_results``.
 
   Overall counts plus a per-``rule_category`` breakdown, so the viewer
-  renders the grouped Verification Results panel (financial-viewer §7.12)
+  renders the grouped Verification Results panel
   without a client-side results→rules join. Status closure is
   ``pass | fail | error | skipped`` (the ``public.verification_results``
   CHECK); ``total`` is their sum.


### PR DESCRIPTION
## Summary

Regenerates the Python client against the latest OpenAPI spec. The backend tightened its endpoint/model descriptions — removing internal spec references (`Phase 2 of §3.2`, `information-block.md §5.2.2`, `Tier 1`/`Tier 2`, "Phase 2 MVP") that had leaked into public descriptions — so the regenerated SDK picks those wording changes up.

## Changes

These are **docstring-only** updates; there are no changes to types, fields, signatures, or runtime behavior:

- `api/graph_operations/op_change_reporting_style.py` — drop `Phase 2 of §3.2` from the operation/body docstrings.
- `api/extensions_robo_ledger/op_create_taxonomy_block.py`, `op_evaluate_rules.py` — docstring wording sync.
- `models/rollforward_mechanics.py` — remove `Tier 1`/`Tier 2`/`information-block.md §4.5` and MVP references from the class docstring.
- `models/taxonomy_block_rule.py`, `taxonomy_block_rule_request.py` — drop `information-block.md §5.2.2` reference.
- `models/change_reporting_style_op.py`, `close_period_response.py`, `list_subgraphs_response.py`, `verification_category_summary.py`, `verification_summary.py` — minor description wording sync.

## Testing

- Pre-commit hook passed: `ruff check` (all passed), `ruff format --check` (clean), `basedpyright` (0 errors, 0 warnings), and the full pytest suite (453 collected).

## Notes

- Purely a generated-output refresh — no public API surface change, so no consumer impact beyond docstrings.
- Version bump / publish remain owned by the maintainer; this PR does not release.
