### PR TITLE
chore(sdk): drop ignore_errors from materialize

### DIFF
--- a/robosystems_client/clients/graph_client.py
+++ b/robosystems_client/clients/graph_client.py
@@ -66,7 +66,6 @@ class GraphInfo:
 class MaterializationOptions:
   """Options for graph materialization operations"""
 
-  ignore_errors: bool = True
   rebuild: bool = False
   force: bool = False
   materialize_embeddings: bool = False
@@ -317,7 +316,7 @@ class GraphClient:
 
     Args:
         graph_id: Graph database identifier
-        options: Materialization options (ignore_errors, rebuild, force, timeout)
+        options: Materialization options (rebuild, force, timeout)
 
     Returns:
         MaterializationResult with detailed execution information
@@ -340,7 +339,6 @@ class GraphClient:
         graph_id=graph_id,
         client=client,
         body=MaterializeOp(
-          ignore_errors=options.ignore_errors,
           rebuild=options.rebuild,
           force=options.force,
           materialize_embeddings=options.materialize_embeddings,

--- a/robosystems_client/models/materialize_op.py
+++ b/robosystems_client/models/materialize_op.py
@@ -18,7 +18,6 @@ class MaterializeOp:
   Attributes:
       force (bool | Unset): Force materialization even if already up to date Default: False.
       rebuild (bool | Unset): Rebuild the graph from scratch, dropping existing data Default: False.
-      ignore_errors (bool | Unset): Continue past non-fatal row errors Default: True.
       dry_run (bool | Unset): Validate tables without writing to the graph Default: False.
       source (None | str | Unset): Materialization source: 'extensions' for OLTP, omit for DuckDB staging tables
       materialize_embeddings (bool | Unset): Generate vector embeddings during materialization Default: False.
@@ -26,7 +25,6 @@ class MaterializeOp:
 
   force: bool | Unset = False
   rebuild: bool | Unset = False
-  ignore_errors: bool | Unset = True
   dry_run: bool | Unset = False
   source: None | str | Unset = UNSET
   materialize_embeddings: bool | Unset = False
@@ -36,8 +34,6 @@ class MaterializeOp:
     force = self.force
 
     rebuild = self.rebuild
-
-    ignore_errors = self.ignore_errors
 
     dry_run = self.dry_run
 
@@ -56,8 +52,6 @@ class MaterializeOp:
       field_dict["force"] = force
     if rebuild is not UNSET:
       field_dict["rebuild"] = rebuild
-    if ignore_errors is not UNSET:
-      field_dict["ignore_errors"] = ignore_errors
     if dry_run is not UNSET:
       field_dict["dry_run"] = dry_run
     if source is not UNSET:
@@ -73,8 +67,6 @@ class MaterializeOp:
     force = d.pop("force", UNSET)
 
     rebuild = d.pop("rebuild", UNSET)
-
-    ignore_errors = d.pop("ignore_errors", UNSET)
 
     dry_run = d.pop("dry_run", UNSET)
 
@@ -92,7 +84,6 @@ class MaterializeOp:
     materialize_op = cls(
       force=force,
       rebuild=rebuild,
-      ignore_errors=ignore_errors,
       dry_run=dry_run,
       source=source,
       materialize_embeddings=materialize_embeddings,

--- a/tests/test_materialization_client.py
+++ b/tests/test_materialization_client.py
@@ -21,7 +21,6 @@ class TestMaterializationDataclasses:
     """Test MaterializationOptions default values."""
     options = MaterializationOptions()
 
-    assert options.ignore_errors is True
     assert options.rebuild is False
     assert options.force is False
     assert options.materialize_embeddings is False
@@ -32,7 +31,6 @@ class TestMaterializationDataclasses:
     """Test MaterializationOptions with custom values."""
     progress_fn = Mock()
     options = MaterializationOptions(
-      ignore_errors=False,
       rebuild=True,
       force=True,
       materialize_embeddings=True,
@@ -40,7 +38,6 @@ class TestMaterializationDataclasses:
       timeout=300,
     )
 
-    assert options.ignore_errors is False
     assert options.rebuild is True
     assert options.force is True
     assert options.materialize_embeddings is True


### PR DESCRIPTION
## Summary

Drop `ignore_errors` from the materialize surface. The API removed the field server-side because LadybugDB 0.18's `COPY (ignore_errors=true)` silently drops valid rows in proportion to batch size — so the flag is gone from `MaterializeOp`, and the facade should no longer send it.

## Changes

- Regenerated `MaterializeOp` without the `ignore_errors` field (model + serde).
- `MaterializationOptions` facade: removed the `ignore_errors` option; `GraphClient.materialize()` no longer passes it to `MaterializeOp`.
- Updated the docstring and the `MaterializationOptions` tests.

## Compatibility

Removing an optional field. Old callers that set `MaterializationOptions(ignore_errors=…)` will need to drop the kwarg, but no behavior changes — the server ignored the value anyway on the current API and now doesn't accept it.

## Testing

- Full test suite green via pre-commit (**439 passed, 17 skipped**).
