### PR TITLE
feat(sdk): regenerate for text-block disclosures (bind-text-block)

### DIFF
--- a/robosystems_client/api/extensions_robo_ledger/bind_text_block.py
+++ b/robosystems_client/api/extensions_robo_ledger/bind_text_block.py
@@ -1,0 +1,274 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.bind_text_block_request import BindTextBlockRequest
+from ...models.error_response import ErrorResponse
+from ...models.operation_envelope_bind_text_block_response import (
+  OperationEnvelopeBindTextBlockResponse,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+  graph_id: str,
+  *,
+  body: BindTextBlockRequest,
+  idempotency_key: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+  headers: dict[str, Any] = {}
+  if not isinstance(idempotency_key, Unset):
+    headers["Idempotency-Key"] = idempotency_key
+
+  _kwargs: dict[str, Any] = {
+    "method": "post",
+    "url": "/extensions/roboledger/{graph_id}/operations/bind-text-block".format(
+      graph_id=quote(str(graph_id), safe=""),
+    ),
+  }
+
+  _kwargs["json"] = body.to_dict()
+
+  headers["Content-Type"] = "application/json"
+
+  _kwargs["headers"] = headers
+  return _kwargs
+
+
+def _parse_response(
+  *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | OperationEnvelopeBindTextBlockResponse | None:
+  if response.status_code == 200:
+    response_200 = OperationEnvelopeBindTextBlockResponse.from_dict(response.json())
+
+    return response_200
+
+  if response.status_code == 400:
+    response_400 = ErrorResponse.from_dict(response.json())
+
+    return response_400
+
+  if response.status_code == 401:
+    response_401 = ErrorResponse.from_dict(response.json())
+
+    return response_401
+
+  if response.status_code == 403:
+    response_403 = ErrorResponse.from_dict(response.json())
+
+    return response_403
+
+  if response.status_code == 404:
+    response_404 = ErrorResponse.from_dict(response.json())
+
+    return response_404
+
+  if response.status_code == 409:
+    response_409 = ErrorResponse.from_dict(response.json())
+
+    return response_409
+
+  if response.status_code == 422:
+    response_422 = ErrorResponse.from_dict(response.json())
+
+    return response_422
+
+  if response.status_code == 429:
+    response_429 = ErrorResponse.from_dict(response.json())
+
+    return response_429
+
+  if response.status_code == 500:
+    response_500 = ErrorResponse.from_dict(response.json())
+
+    return response_500
+
+  if client.raise_on_unexpected_status:
+    raise errors.UnexpectedStatus(response.status_code, response.content)
+  else:
+    return None
+
+
+def _build_response(
+  *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | OperationEnvelopeBindTextBlockResponse]:
+  return Response(
+    status_code=HTTPStatus(response.status_code),
+    content=response.content,
+    headers=response.headers,
+    parsed=_parse_response(client=client, response=response),
+  )
+
+
+def sync_detailed(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BindTextBlockRequest,
+  idempotency_key: None | str | Unset = UNSET,
+) -> Response[ErrorResponse | OperationEnvelopeBindTextBlockResponse]:
+  """Bind Text Block
+
+   Bind a platform Document (markdown) — or one of its sections — to a disclosure element as a
+  Nonnumeric text-block fact. The document stays the editable source of truth; the fact snapshots its
+  text into a standing 'disclosure' FactSet with document provenance (document_id + section +
+  content_hash). Re-binding the same element and period replaces the fact and refreshes the hash.
+  Reports generated afterward snapshot the standing set, so filed reports are immutable against later
+  document edits.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BindTextBlockRequest):
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      Response[ErrorResponse | OperationEnvelopeBindTextBlockResponse]
+  """
+
+  kwargs = _get_kwargs(
+    graph_id=graph_id,
+    body=body,
+    idempotency_key=idempotency_key,
+  )
+
+  response = client.get_httpx_client().request(
+    **kwargs,
+  )
+
+  return _build_response(client=client, response=response)
+
+
+def sync(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BindTextBlockRequest,
+  idempotency_key: None | str | Unset = UNSET,
+) -> ErrorResponse | OperationEnvelopeBindTextBlockResponse | None:
+  """Bind Text Block
+
+   Bind a platform Document (markdown) — or one of its sections — to a disclosure element as a
+  Nonnumeric text-block fact. The document stays the editable source of truth; the fact snapshots its
+  text into a standing 'disclosure' FactSet with document provenance (document_id + section +
+  content_hash). Re-binding the same element and period replaces the fact and refreshes the hash.
+  Reports generated afterward snapshot the standing set, so filed reports are immutable against later
+  document edits.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BindTextBlockRequest):
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      ErrorResponse | OperationEnvelopeBindTextBlockResponse
+  """
+
+  return sync_detailed(
+    graph_id=graph_id,
+    client=client,
+    body=body,
+    idempotency_key=idempotency_key,
+  ).parsed
+
+
+async def asyncio_detailed(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BindTextBlockRequest,
+  idempotency_key: None | str | Unset = UNSET,
+) -> Response[ErrorResponse | OperationEnvelopeBindTextBlockResponse]:
+  """Bind Text Block
+
+   Bind a platform Document (markdown) — or one of its sections — to a disclosure element as a
+  Nonnumeric text-block fact. The document stays the editable source of truth; the fact snapshots its
+  text into a standing 'disclosure' FactSet with document provenance (document_id + section +
+  content_hash). Re-binding the same element and period replaces the fact and refreshes the hash.
+  Reports generated afterward snapshot the standing set, so filed reports are immutable against later
+  document edits.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BindTextBlockRequest):
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      Response[ErrorResponse | OperationEnvelopeBindTextBlockResponse]
+  """
+
+  kwargs = _get_kwargs(
+    graph_id=graph_id,
+    body=body,
+    idempotency_key=idempotency_key,
+  )
+
+  response = await client.get_async_httpx_client().request(**kwargs)
+
+  return _build_response(client=client, response=response)
+
+
+async def asyncio(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BindTextBlockRequest,
+  idempotency_key: None | str | Unset = UNSET,
+) -> ErrorResponse | OperationEnvelopeBindTextBlockResponse | None:
+  """Bind Text Block
+
+   Bind a platform Document (markdown) — or one of its sections — to a disclosure element as a
+  Nonnumeric text-block fact. The document stays the editable source of truth; the fact snapshots its
+  text into a standing 'disclosure' FactSet with document provenance (document_id + section +
+  content_hash). Re-binding the same element and period replaces the fact and refreshes the hash.
+  Reports generated afterward snapshot the standing set, so filed reports are immutable against later
+  document edits.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BindTextBlockRequest):
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      ErrorResponse | OperationEnvelopeBindTextBlockResponse
+  """
+
+  return (
+    await asyncio_detailed(
+      graph_id=graph_id,
+      client=client,
+      body=body,
+      idempotency_key=idempotency_key,
+    )
+  ).parsed

--- a/robosystems_client/clients/ledger_client.py
+++ b/robosystems_client/clients/ledger_client.py
@@ -94,6 +94,9 @@ from ..api.extensions_robo_ledger.update_taxonomy_block import (
 from ..api.extensions_robo_ledger.delete_taxonomy_block import (
   sync_detailed as op_delete_taxonomy_block,
 )
+from ..api.extensions_robo_ledger.bind_text_block import (
+  sync_detailed as op_bind_text_block,
+)
 from ..api.extensions_robo_ledger.evaluate_rules import (
   sync_detailed as op_evaluate_rules,
 )
@@ -287,6 +290,8 @@ from ..models.share_report_operation import ShareReportOperation
 from ..models.update_publish_list_operation import UpdatePublishListOperation
 from ..models.reopen_period_operation import ReopenPeriodOperation
 from ..models.set_close_target_operation import SetCloseTargetOperation
+from ..models.bind_text_block_request import BindTextBlockRequest
+from ..models.bind_text_block_response import BindTextBlockResponse
 from ..models.create_taxonomy_block_request import CreateTaxonomyBlockRequest
 from ..models.update_taxonomy_block_request import UpdateTaxonomyBlockRequest
 from ..models.delete_taxonomy_block_request import DeleteTaxonomyBlockRequest
@@ -798,6 +803,27 @@ class LedgerClient:
     return self._typed_result(
       "Delete taxonomy block", envelope, DeleteTaxonomyBlockResponse
     )
+
+  def bind_text_block(
+    self, graph_id: str, body: dict[str, Any], idempotency_key: str | None = None
+  ) -> BindTextBlockResponse:
+    """Bind a platform Document (or one section) to a disclosure element
+    as a Nonnumeric text-block fact in a standing 'disclosure' FactSet.
+
+    ``body`` mirrors BindTextBlockRequest: document_id, structure_id,
+    exactly one of element_id / element_qname, period_start, period_end,
+    plus optional section_id / entity_id. Re-binding the same element
+    and period replaces the fact (``replaced=True`` in the response).
+    """
+    request = BindTextBlockRequest.from_dict(body)
+    response = op_bind_text_block(
+      graph_id=graph_id,
+      body=request,
+      client=self._get_client(),
+      idempotency_key=idempotency_key if idempotency_key is not None else UNSET,
+    )
+    envelope = self._call_op("Bind text block", response)
+    return self._typed_result("Bind text block", envelope, BindTextBlockResponse)
 
   def link_entity_taxonomy(
     self,

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -25,6 +25,8 @@ from .backup_stats_response_backup_formats import BackupStatsResponseBackupForma
 from .batch_operator_request import BatchOperatorRequest
 from .batch_operator_response import BatchOperatorResponse
 from .billing_customer import BillingCustomer
+from .bind_text_block_request import BindTextBlockRequest
+from .bind_text_block_response import BindTextBlockResponse
 from .cancel_operation_response_canceloperation import (
   CancelOperationResponseCanceloperation,
 )
@@ -296,6 +298,12 @@ from .operation_envelope_association_response import (
 )
 from .operation_envelope_association_response_status import (
   OperationEnvelopeAssociationResponseStatus,
+)
+from .operation_envelope_bind_text_block_response import (
+  OperationEnvelopeBindTextBlockResponse,
+)
+from .operation_envelope_bind_text_block_response_status import (
+  OperationEnvelopeBindTextBlockResponseStatus,
 )
 from .operation_envelope_change_reporting_style_response import (
   OperationEnvelopeChangeReportingStyleResponse,
@@ -645,6 +653,9 @@ from .taxonomy_block_structure_request import TaxonomyBlockStructureRequest
 from .taxonomy_block_structure_request_block_type import (
   TaxonomyBlockStructureRequestBlockType,
 )
+from .taxonomy_block_structure_request_concept_arrangement_type_0 import (
+  TaxonomyBlockStructureRequestConceptArrangementType0,
+)
 from .taxonomy_block_structure_request_metadata import (
   TaxonomyBlockStructureRequestMetadata,
 )
@@ -744,6 +755,8 @@ __all__ = (
   "BatchOperatorRequest",
   "BatchOperatorResponse",
   "BillingCustomer",
+  "BindTextBlockRequest",
+  "BindTextBlockResponse",
   "CancelOperationResponseCanceloperation",
   "CancelSubscriptionRequest",
   "ChangeReportingStyleRequest",
@@ -964,6 +977,8 @@ __all__ = (
   "OperationEnvelope",
   "OperationEnvelopeAssociationResponse",
   "OperationEnvelopeAssociationResponseStatus",
+  "OperationEnvelopeBindTextBlockResponse",
+  "OperationEnvelopeBindTextBlockResponseStatus",
   "OperationEnvelopeChangeReportingStyleResponse",
   "OperationEnvelopeChangeReportingStyleResponseStatus",
   "OperationEnvelopeClosePeriodResponse",
@@ -1180,6 +1195,7 @@ __all__ = (
   "TaxonomyBlockStructure",
   "TaxonomyBlockStructureRequest",
   "TaxonomyBlockStructureRequestBlockType",
+  "TaxonomyBlockStructureRequestConceptArrangementType0",
   "TaxonomyBlockStructureRequestMetadata",
   "TierCapacity",
   "TokenPricing",

--- a/robosystems_client/models/bind_text_block_request.py
+++ b/robosystems_client/models/bind_text_block_request.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="BindTextBlockRequest")
+
+
+@_attrs_define
+class BindTextBlockRequest:
+  """
+  Attributes:
+      document_id (str): Platform Document to bind (see list-documents).
+      structure_id (str): Disclosure Structure the text block belongs to — must be block_type='regulatory_disclosure'
+          with a text-block concept_arrangement (text_block / levelN_textblock).
+      period_start (datetime.date): Reporting period start the narrative covers (duration fact).
+      period_end (datetime.date): Reporting period end.
+      section_id (None | str | Unset): Slugified heading id of one section to bind (the section ids search-documents
+          returns); omit to bind the whole document.
+      element_id (None | str | Unset): Disclosure element to tag the text to (id form).
+      element_qname (None | str | Unset): Disclosure element qname (e.g.
+          'acme:SignificantAccountingPoliciesTextBlock') — exactly one of element_id / element_qname.
+      entity_id (None | str | Unset): Entity the fact belongs to; defaults to the primary entity.
+  """
+
+  document_id: str
+  structure_id: str
+  period_start: datetime.date
+  period_end: datetime.date
+  section_id: None | str | Unset = UNSET
+  element_id: None | str | Unset = UNSET
+  element_qname: None | str | Unset = UNSET
+  entity_id: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    document_id = self.document_id
+
+    structure_id = self.structure_id
+
+    period_start = self.period_start.isoformat()
+
+    period_end = self.period_end.isoformat()
+
+    section_id: None | str | Unset
+    if isinstance(self.section_id, Unset):
+      section_id = UNSET
+    else:
+      section_id = self.section_id
+
+    element_id: None | str | Unset
+    if isinstance(self.element_id, Unset):
+      element_id = UNSET
+    else:
+      element_id = self.element_id
+
+    element_qname: None | str | Unset
+    if isinstance(self.element_qname, Unset):
+      element_qname = UNSET
+    else:
+      element_qname = self.element_qname
+
+    entity_id: None | str | Unset
+    if isinstance(self.entity_id, Unset):
+      entity_id = UNSET
+    else:
+      entity_id = self.entity_id
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "document_id": document_id,
+        "structure_id": structure_id,
+        "period_start": period_start,
+        "period_end": period_end,
+      }
+    )
+    if section_id is not UNSET:
+      field_dict["section_id"] = section_id
+    if element_id is not UNSET:
+      field_dict["element_id"] = element_id
+    if element_qname is not UNSET:
+      field_dict["element_qname"] = element_qname
+    if entity_id is not UNSET:
+      field_dict["entity_id"] = entity_id
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    document_id = d.pop("document_id")
+
+    structure_id = d.pop("structure_id")
+
+    period_start = datetime.date.fromisoformat(d.pop("period_start"))
+
+    period_end = datetime.date.fromisoformat(d.pop("period_end"))
+
+    def _parse_section_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    section_id = _parse_section_id(d.pop("section_id", UNSET))
+
+    def _parse_element_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    element_id = _parse_element_id(d.pop("element_id", UNSET))
+
+    def _parse_element_qname(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    element_qname = _parse_element_qname(d.pop("element_qname", UNSET))
+
+    def _parse_entity_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    entity_id = _parse_entity_id(d.pop("entity_id", UNSET))
+
+    bind_text_block_request = cls(
+      document_id=document_id,
+      structure_id=structure_id,
+      period_start=period_start,
+      period_end=period_end,
+      section_id=section_id,
+      element_id=element_id,
+      element_qname=element_qname,
+      entity_id=entity_id,
+    )
+
+    bind_text_block_request.additional_properties = d
+    return bind_text_block_request
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/bind_text_block_response.py
+++ b/robosystems_client/models/bind_text_block_response.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="BindTextBlockResponse")
+
+
+@_attrs_define
+class BindTextBlockResponse:
+  """
+  Attributes:
+      fact_id (str): The Nonnumeric Fact created.
+      fact_set_id (str): Standing 'disclosure' FactSet holding the fact.
+      structure_id (str):
+      element_id (str):
+      document_id (str):
+      content_hash (str): Full sha256 hex of the bound text (drift signal).
+      characters (int): Length of the bound text.
+      period_start (datetime.date):
+      period_end (datetime.date):
+      replaced (bool): True when a re-bind replaced this element's existing fact in the standing FactSet (content and
+          provenance refreshed).
+      section_id (None | str | Unset):
+  """
+
+  fact_id: str
+  fact_set_id: str
+  structure_id: str
+  element_id: str
+  document_id: str
+  content_hash: str
+  characters: int
+  period_start: datetime.date
+  period_end: datetime.date
+  replaced: bool
+  section_id: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    fact_id = self.fact_id
+
+    fact_set_id = self.fact_set_id
+
+    structure_id = self.structure_id
+
+    element_id = self.element_id
+
+    document_id = self.document_id
+
+    content_hash = self.content_hash
+
+    characters = self.characters
+
+    period_start = self.period_start.isoformat()
+
+    period_end = self.period_end.isoformat()
+
+    replaced = self.replaced
+
+    section_id: None | str | Unset
+    if isinstance(self.section_id, Unset):
+      section_id = UNSET
+    else:
+      section_id = self.section_id
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "fact_id": fact_id,
+        "fact_set_id": fact_set_id,
+        "structure_id": structure_id,
+        "element_id": element_id,
+        "document_id": document_id,
+        "content_hash": content_hash,
+        "characters": characters,
+        "period_start": period_start,
+        "period_end": period_end,
+        "replaced": replaced,
+      }
+    )
+    if section_id is not UNSET:
+      field_dict["section_id"] = section_id
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    fact_id = d.pop("fact_id")
+
+    fact_set_id = d.pop("fact_set_id")
+
+    structure_id = d.pop("structure_id")
+
+    element_id = d.pop("element_id")
+
+    document_id = d.pop("document_id")
+
+    content_hash = d.pop("content_hash")
+
+    characters = d.pop("characters")
+
+    period_start = datetime.date.fromisoformat(d.pop("period_start"))
+
+    period_end = datetime.date.fromisoformat(d.pop("period_end"))
+
+    replaced = d.pop("replaced")
+
+    def _parse_section_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    section_id = _parse_section_id(d.pop("section_id", UNSET))
+
+    bind_text_block_response = cls(
+      fact_id=fact_id,
+      fact_set_id=fact_set_id,
+      structure_id=structure_id,
+      element_id=element_id,
+      document_id=document_id,
+      content_hash=content_hash,
+      characters=characters,
+      period_start=period_start,
+      period_end=period_end,
+      replaced=replaced,
+      section_id=section_id,
+    )
+
+    bind_text_block_response.additional_properties = d
+    return bind_text_block_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/create_legacy_arm.py
+++ b/robosystems_client/models/create_legacy_arm.py
@@ -23,10 +23,13 @@ class CreateLegacyArm:
 
   Statement-family blocks (balance_sheet, income_statement,
   cash_flow_statement, equity_statement, comprehensive_income) are
-  constructed via `create-report`, not this endpoint. Metric blocks
-  are recognized but their evaluator has not shipped. Calling this
-  endpoint with one of these block types returns HTTP 501 with a hint
-  pointing to the correct construction path.
+  constructed via `create-report`, not this endpoint. Disclosure
+  structures (regulatory_disclosure) are vocabulary, authored via
+  `create-taxonomy-block`; their facts land when `create-report`
+  picks them. Metric blocks are recognized but their evaluator has
+  not shipped. Calling this endpoint with one of these block types
+  returns HTTP 501 with a hint pointing to the correct construction
+  path.
 
       Attributes:
           block_type (CreateLegacyArmBlockType): Statement-family or metric block type. The endpoint returns 501 for these

--- a/robosystems_client/models/create_legacy_arm_block_type.py
+++ b/robosystems_client/models/create_legacy_arm_block_type.py
@@ -8,6 +8,7 @@ class CreateLegacyArmBlockType(str, Enum):
   EQUITY_STATEMENT = "equity_statement"
   INCOME_STATEMENT = "income_statement"
   METRIC = "metric"
+  REGULATORY_DISCLOSURE = "regulatory_disclosure"
 
   def __str__(self) -> str:
     return str(self.value)

--- a/robosystems_client/models/delete_legacy_arm_block_type.py
+++ b/robosystems_client/models/delete_legacy_arm_block_type.py
@@ -8,6 +8,7 @@ class DeleteLegacyArmBlockType(str, Enum):
   EQUITY_STATEMENT = "equity_statement"
   INCOME_STATEMENT = "income_statement"
   METRIC = "metric"
+  REGULATORY_DISCLOSURE = "regulatory_disclosure"
 
   def __str__(self) -> str:
     return str(self.value)

--- a/robosystems_client/models/fact_lite.py
+++ b/robosystems_client/models/fact_lite.py
@@ -19,12 +19,15 @@ class FactLite:
   Attributes:
       id (str):
       element_id (str):
-      value (float):
       period_end (datetime.date):
       period_type (str):
       fact_scope (str): historical | in_scope
       element_name (None | str | Unset):
       element_qname (None | str | Unset):
+      value (float | None | Unset): Numeric value; null for Nonnumeric (text-block) facts.
+      text_value (None | str | Unset): Text payload for Nonnumeric facts; null for numeric.
+      fact_type (str | Unset): Numeric | Nonnumeric Default: 'Numeric'.
+      content_type (None | str | Unset): MIME type of text_value (e.g. 'text/markdown').
       period_start (datetime.date | None | Unset):
       unit (str | Unset):  Default: 'USD'.
       fact_set_id (None | str | Unset):
@@ -32,12 +35,15 @@ class FactLite:
 
   id: str
   element_id: str
-  value: float
   period_end: datetime.date
   period_type: str
   fact_scope: str
   element_name: None | str | Unset = UNSET
   element_qname: None | str | Unset = UNSET
+  value: float | None | Unset = UNSET
+  text_value: None | str | Unset = UNSET
+  fact_type: str | Unset = "Numeric"
+  content_type: None | str | Unset = UNSET
   period_start: datetime.date | None | Unset = UNSET
   unit: str | Unset = "USD"
   fact_set_id: None | str | Unset = UNSET
@@ -47,8 +53,6 @@ class FactLite:
     id = self.id
 
     element_id = self.element_id
-
-    value = self.value
 
     period_end = self.period_end.isoformat()
 
@@ -67,6 +71,26 @@ class FactLite:
       element_qname = UNSET
     else:
       element_qname = self.element_qname
+
+    value: float | None | Unset
+    if isinstance(self.value, Unset):
+      value = UNSET
+    else:
+      value = self.value
+
+    text_value: None | str | Unset
+    if isinstance(self.text_value, Unset):
+      text_value = UNSET
+    else:
+      text_value = self.text_value
+
+    fact_type = self.fact_type
+
+    content_type: None | str | Unset
+    if isinstance(self.content_type, Unset):
+      content_type = UNSET
+    else:
+      content_type = self.content_type
 
     period_start: None | str | Unset
     if isinstance(self.period_start, Unset):
@@ -90,7 +114,6 @@ class FactLite:
       {
         "id": id,
         "element_id": element_id,
-        "value": value,
         "period_end": period_end,
         "period_type": period_type,
         "fact_scope": fact_scope,
@@ -100,6 +123,14 @@ class FactLite:
       field_dict["element_name"] = element_name
     if element_qname is not UNSET:
       field_dict["element_qname"] = element_qname
+    if value is not UNSET:
+      field_dict["value"] = value
+    if text_value is not UNSET:
+      field_dict["text_value"] = text_value
+    if fact_type is not UNSET:
+      field_dict["fact_type"] = fact_type
+    if content_type is not UNSET:
+      field_dict["content_type"] = content_type
     if period_start is not UNSET:
       field_dict["period_start"] = period_start
     if unit is not UNSET:
@@ -115,8 +146,6 @@ class FactLite:
     id = d.pop("id")
 
     element_id = d.pop("element_id")
-
-    value = d.pop("value")
 
     period_end = datetime.date.fromisoformat(d.pop("period_end"))
 
@@ -141,6 +170,35 @@ class FactLite:
       return cast(None | str | Unset, data)
 
     element_qname = _parse_element_qname(d.pop("element_qname", UNSET))
+
+    def _parse_value(data: object) -> float | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(float | None | Unset, data)
+
+    value = _parse_value(d.pop("value", UNSET))
+
+    def _parse_text_value(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    text_value = _parse_text_value(d.pop("text_value", UNSET))
+
+    fact_type = d.pop("fact_type", UNSET)
+
+    def _parse_content_type(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    content_type = _parse_content_type(d.pop("content_type", UNSET))
 
     def _parse_period_start(data: object) -> datetime.date | None | Unset:
       if data is None:
@@ -173,12 +231,15 @@ class FactLite:
     fact_lite = cls(
       id=id,
       element_id=element_id,
-      value=value,
       period_end=period_end,
       period_type=period_type,
       fact_scope=fact_scope,
       element_name=element_name,
       element_qname=element_qname,
+      value=value,
+      text_value=text_value,
+      fact_type=fact_type,
+      content_type=content_type,
       period_start=period_start,
       unit=unit,
       fact_set_id=fact_set_id,

--- a/robosystems_client/models/fact_set_lite.py
+++ b/robosystems_client/models/fact_set_lite.py
@@ -28,8 +28,8 @@ class FactSetLite:
       Attributes:
           id (str):
           period_end (datetime.date):
-          factset_type (str): 'report' | 'schedule' | 'custom'. Enum closure enforced by the ``public.fact_sets`` CHECK
-              constraint.
+          factset_type (str): 'report' | 'schedule' | 'custom' | 'disclosure'. Enum closure enforced by the
+              ``public.fact_sets`` CHECK constraint.
           entity_id (str):
           structure_id (None | str | Unset):
           period_start (datetime.date | None | Unset):

--- a/robosystems_client/models/operation_envelope_bind_text_block_response.py
+++ b/robosystems_client/models/operation_envelope_bind_text_block_response.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.operation_envelope_bind_text_block_response_status import (
+  OperationEnvelopeBindTextBlockResponseStatus,
+)
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.bind_text_block_response import BindTextBlockResponse
+
+
+T = TypeVar("T", bound="OperationEnvelopeBindTextBlockResponse")
+
+
+@_attrs_define
+class OperationEnvelopeBindTextBlockResponse:
+  """
+  Attributes:
+      operation (str): Kebab-case operation name
+      operation_id (str): op_-prefixed ULID for audit and SSE correlation
+      status (OperationEnvelopeBindTextBlockResponseStatus): Operation lifecycle state
+      at (str): ISO-8601 UTC timestamp
+      result (BindTextBlockResponse | None | Unset): Command-specific result payload
+      created_by (None | str | Unset): User ID that initiated the operation (null for legacy callers)
+      idempotent_replay (bool | Unset): True when this envelope came from the idempotency cache — the underlying
+          command did not execute again. False on fresh executions. Default: False.
+  """
+
+  operation: str
+  operation_id: str
+  status: OperationEnvelopeBindTextBlockResponseStatus
+  at: str
+  result: BindTextBlockResponse | None | Unset = UNSET
+  created_by: None | str | Unset = UNSET
+  idempotent_replay: bool | Unset = False
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.bind_text_block_response import BindTextBlockResponse
+
+    operation = self.operation
+
+    operation_id = self.operation_id
+
+    status = self.status.value
+
+    at = self.at
+
+    result: dict[str, Any] | None | Unset
+    if isinstance(self.result, Unset):
+      result = UNSET
+    elif isinstance(self.result, BindTextBlockResponse):
+      result = self.result.to_dict()
+    else:
+      result = self.result
+
+    created_by: None | str | Unset
+    if isinstance(self.created_by, Unset):
+      created_by = UNSET
+    else:
+      created_by = self.created_by
+
+    idempotent_replay = self.idempotent_replay
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "operation": operation,
+        "operationId": operation_id,
+        "status": status,
+        "at": at,
+      }
+    )
+    if result is not UNSET:
+      field_dict["result"] = result
+    if created_by is not UNSET:
+      field_dict["createdBy"] = created_by
+    if idempotent_replay is not UNSET:
+      field_dict["idempotentReplay"] = idempotent_replay
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.bind_text_block_response import BindTextBlockResponse
+
+    d = dict(src_dict)
+    operation = d.pop("operation")
+
+    operation_id = d.pop("operationId")
+
+    status = OperationEnvelopeBindTextBlockResponseStatus(d.pop("status"))
+
+    at = d.pop("at")
+
+    def _parse_result(data: object) -> BindTextBlockResponse | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        result_type_0 = BindTextBlockResponse.from_dict(data)
+
+        return result_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(BindTextBlockResponse | None | Unset, data)
+
+    result = _parse_result(d.pop("result", UNSET))
+
+    def _parse_created_by(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    created_by = _parse_created_by(d.pop("createdBy", UNSET))
+
+    idempotent_replay = d.pop("idempotentReplay", UNSET)
+
+    operation_envelope_bind_text_block_response = cls(
+      operation=operation,
+      operation_id=operation_id,
+      status=status,
+      at=at,
+      result=result,
+      created_by=created_by,
+      idempotent_replay=idempotent_replay,
+    )
+
+    operation_envelope_bind_text_block_response.additional_properties = d
+    return operation_envelope_bind_text_block_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_bind_text_block_response_status.py
+++ b/robosystems_client/models/operation_envelope_bind_text_block_response_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class OperationEnvelopeBindTextBlockResponseStatus(str, Enum):
+  COMPLETED = "completed"
+  FAILED = "failed"
+  PENDING = "pending"
+
+  def __str__(self) -> str:
+    return str(self.value)

--- a/robosystems_client/models/rendering_row_lite.py
+++ b/robosystems_client/models/rendering_row_lite.py
@@ -30,6 +30,8 @@ class RenderingRowLite:
               lookup.
           balance_type (None | str | Unset):
           values (list[float | None] | Unset):
+          text_value (None | str | Unset): Narrative payload for text-block disclosure rows (markdown); numeric rows carry
+              values instead.
           is_subtotal (bool | Unset):  Default: False.
           depth (int | Unset):  Default: 0.
   """
@@ -40,6 +42,7 @@ class RenderingRowLite:
   classification: None | str | Unset = UNSET
   balance_type: None | str | Unset = UNSET
   values: list[float | None] | Unset = UNSET
+  text_value: None | str | Unset = UNSET
   is_subtotal: bool | Unset = False
   depth: int | Unset = 0
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -75,6 +78,12 @@ class RenderingRowLite:
         values_item = values_item_data
         values.append(values_item)
 
+    text_value: None | str | Unset
+    if isinstance(self.text_value, Unset):
+      text_value = UNSET
+    else:
+      text_value = self.text_value
+
     is_subtotal = self.is_subtotal
 
     depth = self.depth
@@ -95,6 +104,8 @@ class RenderingRowLite:
       field_dict["balance_type"] = balance_type
     if values is not UNSET:
       field_dict["values"] = values
+    if text_value is not UNSET:
+      field_dict["text_value"] = text_value
     if is_subtotal is not UNSET:
       field_dict["is_subtotal"] = is_subtotal
     if depth is not UNSET:
@@ -151,6 +162,15 @@ class RenderingRowLite:
 
         values.append(values_item)
 
+    def _parse_text_value(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    text_value = _parse_text_value(d.pop("text_value", UNSET))
+
     is_subtotal = d.pop("is_subtotal", UNSET)
 
     depth = d.pop("depth", UNSET)
@@ -162,6 +182,7 @@ class RenderingRowLite:
       classification=classification,
       balance_type=balance_type,
       values=values,
+      text_value=text_value,
       is_subtotal=is_subtotal,
       depth=depth,
     )

--- a/robosystems_client/models/taxonomy_block_structure_request.py
+++ b/robosystems_client/models/taxonomy_block_structure_request.py
@@ -9,6 +9,9 @@ from attrs import field as _attrs_field
 from ..models.taxonomy_block_structure_request_block_type import (
   TaxonomyBlockStructureRequestBlockType,
 )
+from ..models.taxonomy_block_structure_request_concept_arrangement_type_0 import (
+  TaxonomyBlockStructureRequestConceptArrangementType0,
+)
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -27,8 +30,11 @@ class TaxonomyBlockStructureRequest:
   Attributes:
       name (str): Envelope-local structure name (unique within envelope).
       block_type (TaxonomyBlockStructureRequestBlockType): DB ``structures.block_type`` enum. CoA blocks use
-          ``chart_of_accounts``; reporting extensions use the statement family or ``custom``; custom ontology uses
-          ``custom``.
+          ``chart_of_accounts``; reporting extensions use the statement family, ``regulatory_disclosure`` (disclosure
+          notes), or ``custom``; custom ontology uses ``custom``.
+      concept_arrangement (None | TaxonomyBlockStructureRequestConceptArrangementType0 | Unset): Concept Arrangement
+          Pattern (CAP) — how the structure's concepts relate (mirrors the ``structures.concept_arrangement`` CHECK
+          vocabulary). A disclosure note footing members to a total is ``roll_up``. Null leaves the pattern unset.
       description (None | str | Unset):
       role_uri (None | str | Unset):
       metadata (TaxonomyBlockStructureRequestMetadata | Unset):
@@ -36,6 +42,9 @@ class TaxonomyBlockStructureRequest:
 
   name: str
   block_type: TaxonomyBlockStructureRequestBlockType
+  concept_arrangement: (
+    None | TaxonomyBlockStructureRequestConceptArrangementType0 | Unset
+  ) = UNSET
   description: None | str | Unset = UNSET
   role_uri: None | str | Unset = UNSET
   metadata: TaxonomyBlockStructureRequestMetadata | Unset = UNSET
@@ -45,6 +54,16 @@ class TaxonomyBlockStructureRequest:
     name = self.name
 
     block_type = self.block_type.value
+
+    concept_arrangement: None | str | Unset
+    if isinstance(self.concept_arrangement, Unset):
+      concept_arrangement = UNSET
+    elif isinstance(
+      self.concept_arrangement, TaxonomyBlockStructureRequestConceptArrangementType0
+    ):
+      concept_arrangement = self.concept_arrangement.value
+    else:
+      concept_arrangement = self.concept_arrangement
 
     description: None | str | Unset
     if isinstance(self.description, Unset):
@@ -70,6 +89,8 @@ class TaxonomyBlockStructureRequest:
         "block_type": block_type,
       }
     )
+    if concept_arrangement is not UNSET:
+      field_dict["concept_arrangement"] = concept_arrangement
     if description is not UNSET:
       field_dict["description"] = description
     if role_uri is not UNSET:
@@ -89,6 +110,31 @@ class TaxonomyBlockStructureRequest:
     name = d.pop("name")
 
     block_type = TaxonomyBlockStructureRequestBlockType(d.pop("block_type"))
+
+    def _parse_concept_arrangement(
+      data: object,
+    ) -> None | TaxonomyBlockStructureRequestConceptArrangementType0 | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, str):
+          raise TypeError()
+        concept_arrangement_type_0 = (
+          TaxonomyBlockStructureRequestConceptArrangementType0(data)
+        )
+
+        return concept_arrangement_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(
+        None | TaxonomyBlockStructureRequestConceptArrangementType0 | Unset, data
+      )
+
+    concept_arrangement = _parse_concept_arrangement(
+      d.pop("concept_arrangement", UNSET)
+    )
 
     def _parse_description(data: object) -> None | str | Unset:
       if data is None:
@@ -118,6 +164,7 @@ class TaxonomyBlockStructureRequest:
     taxonomy_block_structure_request = cls(
       name=name,
       block_type=block_type,
+      concept_arrangement=concept_arrangement,
       description=description,
       role_uri=role_uri,
       metadata=metadata,

--- a/robosystems_client/models/taxonomy_block_structure_request_block_type.py
+++ b/robosystems_client/models/taxonomy_block_structure_request_block_type.py
@@ -12,6 +12,7 @@ class TaxonomyBlockStructureRequestBlockType(str, Enum):
   METRIC = "metric"
   POLICY = "policy"
   RECONCILIATION = "reconciliation"
+  REGULATORY_DISCLOSURE = "regulatory_disclosure"
   ROLLFORWARD = "rollforward"
   SCHEDULE = "schedule"
 

--- a/robosystems_client/models/taxonomy_block_structure_request_concept_arrangement_type_0.py
+++ b/robosystems_client/models/taxonomy_block_structure_request_concept_arrangement_type_0.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+
+class TaxonomyBlockStructureRequestConceptArrangementType0(str, Enum):
+  ADJUSTMENT = "adjustment"
+  ARITHMETIC = "arithmetic"
+  COMPOUND_FACT = "compound_fact"
+  GRID = "grid"
+  LEVEL1_TEXTBLOCK = "level1_textblock"
+  LEVEL2_TEXTBLOCK = "level2_textblock"
+  LEVEL3_TEXTBLOCK = "level3_textblock"
+  LEVEL4_DETAIL = "level4_detail"
+  ROLL_FORWARD = "roll_forward"
+  ROLL_FORWARD_INFO = "roll_forward_info"
+  ROLL_UP = "roll_up"
+  SET = "set"
+  TABLE_EQUIVALENT_TEXTBLOCK = "table_equivalent_textblock"
+  TEXT_BLOCK = "text_block"
+  VARIANCE = "variance"
+
+  def __str__(self) -> str:
+    return str(self.value)

--- a/robosystems_client/models/update_legacy_arm_block_type.py
+++ b/robosystems_client/models/update_legacy_arm_block_type.py
@@ -8,6 +8,7 @@ class UpdateLegacyArmBlockType(str, Enum):
   EQUITY_STATEMENT = "equity_statement"
   INCOME_STATEMENT = "income_statement"
   METRIC = "metric"
+  REGULATORY_DISCLOSURE = "regulatory_disclosure"
 
   def __str__(self) -> str:
     return str(self.value)


### PR DESCRIPTION
## Summary

Regeneration against the post-M3 API (robosystems #888/#889):

- New `bind-text-block` operation module + `BindTextBlockRequest`/`BindTextBlockResponse`/envelope models.
- `FactLite` / `RenderingRowLite` gain the non-numeric fields (`text_value`, `fact_type`, `content_type`; `value` nullable) so text-block disclosure envelopes round-trip.
- `TaxonomyBlockStructureRequest` now carries `regulatory_disclosure` + the `concept_arrangement` enum — the gap that forced demo callers onto raw HTTP.
- `FactSetLite.factset_type` admits `'disclosure'`.
- Hand-written `LedgerClient.bind_text_block` wrapper (same shape as the taxonomy-block ops).

## Testing

`just test-all`: 439 passed, ruff + format + basedpyright clean.