### PR TITLE
fix(graphql): select text-block fields on fact and rendering rows

### DIFF
--- a/robosystems_client/graphql/queries/ledger/__init__.py
+++ b/robosystems_client/graphql/queries/ledger/__init__.py
@@ -612,7 +612,7 @@ query GetInformationBlock($id: ID!) {
       arcrole orderValue weight
     }
     facts {
-      id elementId value periodStart periodEnd
+      id elementId value textValue factType contentType periodStart periodEnd
       periodType unit factScope factSetId
     }
     rules {
@@ -637,7 +637,7 @@ query GetInformationBlock($id: ID!) {
       rendering {
         rows {
           elementId elementQname elementName classification
-          balanceType values isSubtotal depth
+          balanceType values textValue isSubtotal depth
         }
         periods { start end label }
         validation { passed checks failures warnings }
@@ -680,7 +680,7 @@ query ListInformationBlocks(
       arcrole orderValue weight
     }
     facts {
-      id elementId value periodStart periodEnd
+      id elementId value textValue factType contentType periodStart periodEnd
       periodType unit factScope factSetId
     }
     rules {
@@ -705,7 +705,7 @@ query ListInformationBlocks(
       rendering {
         rows {
           elementId elementQname elementName classification
-          balanceType values isSubtotal depth
+          balanceType values textValue isSubtotal depth
         }
         periods { start end label }
         validation { passed checks failures warnings }
@@ -906,7 +906,7 @@ query GetLedgerReportPackage($reportId: String!) {
           arcrole orderValue weight
         }
         facts {
-          id elementId value periodStart periodEnd
+          id elementId value textValue factType contentType periodStart periodEnd
           periodType unit factScope factSetId
         }
         rules {
@@ -931,7 +931,7 @@ query GetLedgerReportPackage($reportId: String!) {
           rendering {
             rows {
               elementId elementQname elementName classification
-              balanceType values isSubtotal depth
+              balanceType values textValue isSubtotal depth
             }
             periods { start end label }
             validation { passed checks failures warnings }


### PR DESCRIPTION
## Summary

Follow-up to #140: the regen updated the generated models but the hand-written GraphQL query documents never selected the new fields, so `list_information_blocks` / `get_information_block` / the report-package read returned narrative disclosure envelopes with `text_value`/`fact_type`/`content_type` silently absent. Adds the fields to all three fact selections and `textValue` to the rendering-row selections.

## Testing

`just test-all`: 439 passed, ruff + format + basedpyright clean. Verified against the local backend: the policies note now round-trips its markdown through `list_information_blocks`.