### PR TITLE
feat(sdk): regen — F-2 articulation response + F-4 series seam flag

### DIFF
--- a/robosystems_client/models/compute_forecast_response.py
+++ b/robosystems_client/models/compute_forecast_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -28,6 +28,8 @@ class ComputeForecastResponse:
       months (int): Forward months requested.
       months_computed (list[ForecastMonthLite] | Unset):
       skipped (list[SkippedForecastLite] | Unset):
+      diagnostics (list[str] | Unset): Articulation notes — a missing cash/earnings anchor, schedule contributions
+          with no base-set landing spot, an absent cash-flow structure. Informational; the walk still computed.
   """
 
   structure_id: str
@@ -37,6 +39,7 @@ class ComputeForecastResponse:
   months: int
   months_computed: list[ForecastMonthLite] | Unset = UNSET
   skipped: list[SkippedForecastLite] | Unset = UNSET
+  diagnostics: list[str] | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -64,6 +67,10 @@ class ComputeForecastResponse:
         skipped_item = skipped_item_data.to_dict()
         skipped.append(skipped_item)
 
+    diagnostics: list[str] | Unset = UNSET
+    if not isinstance(self.diagnostics, Unset):
+      diagnostics = self.diagnostics
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -79,6 +86,8 @@ class ComputeForecastResponse:
       field_dict["months_computed"] = months_computed
     if skipped is not UNSET:
       field_dict["skipped"] = skipped
+    if diagnostics is not UNSET:
+      field_dict["diagnostics"] = diagnostics
 
     return field_dict
 
@@ -116,6 +125,8 @@ class ComputeForecastResponse:
 
         skipped.append(skipped_item)
 
+    diagnostics = cast(list[str], d.pop("diagnostics", UNSET))
+
     compute_forecast_response = cls(
       structure_id=structure_id,
       scenario_id=scenario_id,
@@ -124,6 +135,7 @@ class ComputeForecastResponse:
       months=months,
       months_computed=months_computed,
       skipped=skipped,
+      diagnostics=diagnostics,
     )
 
     compute_forecast_response.additional_properties = d

--- a/robosystems_client/models/forecast_month_lite.py
+++ b/robosystems_client/models/forecast_month_lite.py
@@ -21,9 +21,15 @@ class ForecastMonthLite:
       period_start (datetime.date):
       period_end (datetime.date):
       income_statement_fact_set_id (None | str | Unset): Scenario IS FactSet upserted for the month.
-      balance_sheet_fact_set_id (None | str | Unset): Scenario BS FactSet upserted for the month (working-capital
-          instants only in F-1 — the full BS roll is a later phase).
-      computed_count (int | Unset): Number of facts emitted for the month across both sets. Default: 0.
+      balance_sheet_fact_set_id (None | str | Unset): Scenario BS FactSet upserted for the month — the full roll:
+          carry-forward, rule-driven working capital, schedule movements, RE roll, balancing cash (A = L + E by
+          construction).
+      cash_flow_fact_set_id (None | str | Unset): Scenario CF FactSet upserted for the month — indirect-method,
+          derived from BS deltas + NI, reconciled to the balancing ΔCash.
+      computed_count (int | Unset): Number of facts emitted for the month across all sets. Default: 0.
+      verification_passed (bool | None | Unset): Whether every rule evaluated against the month's scenario sets passed
+          (None = no rules ran for the month).
+      verification_failures (list[str] | Unset): Failed/errored rule messages for the month (capped).
   """
 
   period: str
@@ -31,7 +37,10 @@ class ForecastMonthLite:
   period_end: datetime.date
   income_statement_fact_set_id: None | str | Unset = UNSET
   balance_sheet_fact_set_id: None | str | Unset = UNSET
+  cash_flow_fact_set_id: None | str | Unset = UNSET
   computed_count: int | Unset = 0
+  verification_passed: bool | None | Unset = UNSET
+  verification_failures: list[str] | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -53,7 +62,23 @@ class ForecastMonthLite:
     else:
       balance_sheet_fact_set_id = self.balance_sheet_fact_set_id
 
+    cash_flow_fact_set_id: None | str | Unset
+    if isinstance(self.cash_flow_fact_set_id, Unset):
+      cash_flow_fact_set_id = UNSET
+    else:
+      cash_flow_fact_set_id = self.cash_flow_fact_set_id
+
     computed_count = self.computed_count
+
+    verification_passed: bool | None | Unset
+    if isinstance(self.verification_passed, Unset):
+      verification_passed = UNSET
+    else:
+      verification_passed = self.verification_passed
+
+    verification_failures: list[str] | Unset = UNSET
+    if not isinstance(self.verification_failures, Unset):
+      verification_failures = self.verification_failures
 
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
@@ -68,8 +93,14 @@ class ForecastMonthLite:
       field_dict["income_statement_fact_set_id"] = income_statement_fact_set_id
     if balance_sheet_fact_set_id is not UNSET:
       field_dict["balance_sheet_fact_set_id"] = balance_sheet_fact_set_id
+    if cash_flow_fact_set_id is not UNSET:
+      field_dict["cash_flow_fact_set_id"] = cash_flow_fact_set_id
     if computed_count is not UNSET:
       field_dict["computed_count"] = computed_count
+    if verification_passed is not UNSET:
+      field_dict["verification_passed"] = verification_passed
+    if verification_failures is not UNSET:
+      field_dict["verification_failures"] = verification_failures
 
     return field_dict
 
@@ -104,7 +135,31 @@ class ForecastMonthLite:
       d.pop("balance_sheet_fact_set_id", UNSET)
     )
 
+    def _parse_cash_flow_fact_set_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    cash_flow_fact_set_id = _parse_cash_flow_fact_set_id(
+      d.pop("cash_flow_fact_set_id", UNSET)
+    )
+
     computed_count = d.pop("computed_count", UNSET)
+
+    def _parse_verification_passed(data: object) -> bool | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(bool | None | Unset, data)
+
+    verification_passed = _parse_verification_passed(
+      d.pop("verification_passed", UNSET)
+    )
+
+    verification_failures = cast(list[str], d.pop("verification_failures", UNSET))
 
     forecast_month_lite = cls(
       period=period,
@@ -112,7 +167,10 @@ class ForecastMonthLite:
       period_end=period_end,
       income_statement_fact_set_id=income_statement_fact_set_id,
       balance_sheet_fact_set_id=balance_sheet_fact_set_id,
+      cash_flow_fact_set_id=cash_flow_fact_set_id,
       computed_count=computed_count,
+      verification_passed=verification_passed,
+      verification_failures=verification_failures,
     )
 
     forecast_month_lite.additional_properties = d

--- a/robosystems_client/models/rendering_period_lite.py
+++ b/robosystems_client/models/rendering_period_lite.py
@@ -20,11 +20,15 @@ class RenderingPeriodLite:
       start (datetime.date):
       end (datetime.date):
       label (None | str | Unset):
+      forecast (bool | None | Unset): True when this column comes from a forecast scenario's FactSet — the machine-
+          readable seam marker (labels also carry a '(forecast)' suffix, but consumers should key styling off this flag,
+          not label parsing). None/absent = an actuals column.
   """
 
   start: datetime.date
   end: datetime.date
   label: None | str | Unset = UNSET
+  forecast: bool | None | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -38,6 +42,12 @@ class RenderingPeriodLite:
     else:
       label = self.label
 
+    forecast: bool | None | Unset
+    if isinstance(self.forecast, Unset):
+      forecast = UNSET
+    else:
+      forecast = self.forecast
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -48,6 +58,8 @@ class RenderingPeriodLite:
     )
     if label is not UNSET:
       field_dict["label"] = label
+    if forecast is not UNSET:
+      field_dict["forecast"] = forecast
 
     return field_dict
 
@@ -67,10 +79,20 @@ class RenderingPeriodLite:
 
     label = _parse_label(d.pop("label", UNSET))
 
+    def _parse_forecast(data: object) -> bool | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(bool | None | Unset, data)
+
+    forecast = _parse_forecast(d.pop("forecast", UNSET))
+
     rendering_period_lite = cls(
       start=start,
       end=end,
       label=label,
+      forecast=forecast,
     )
 
     rendering_period_lite.additional_properties = d


### PR DESCRIPTION
OpenAPI regen against the combined robosystems #920 (F-2 articulation) + #921 (F-4 statement-series) surface:

- `ForecastMonthLite`: `cash_flow_fact_set_id`, `verification_passed`, `verification_failures`
- `ComputeForecastResponse`: `diagnostics`
- `RenderingPeriodLite`: `forecast` — the machine-readable seam marker on forecast columns

439 passed. Merge after the backend PRs; publish on your cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)