### PR TITLE
feat(sdk): regen — close statement-stamp fields + element documentation

### DIFF
--- a/robosystems_client/api/extensions_robo_ledger/close_period.py
+++ b/robosystems_client/api/extensions_robo_ledger/close_period.py
@@ -114,10 +114,13 @@ def sync_detailed(
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
-  `closed_through` by one, and auto-advances `close_target` if this close caught up to it. Period must
-  be exactly `closed_through + 1` — sequence violations return 422 with structured `blockers`. Common
-  blockers: `sync_stale` (override with `allow_stale_sync=true` after manual verification),
-  `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-order).
+  `closed_through` by one, auto-advances `close_target` if this close caught up to it, and stamps the
+  period's canonical statement FactSets from the posted ledger (`statements_stamped` /
+  `stamped_statement_sets` in the response; soft-skipped with `statement_stamp_note` when reporting
+  isn't set up). Period must be exactly `closed_through + 1` — sequence violations return 422 with
+  structured `blockers`. Common blockers: `sync_stale` (override with `allow_stale_sync=true` after
+  manual verification), `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-
+  order).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -161,10 +164,13 @@ def sync(
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
-  `closed_through` by one, and auto-advances `close_target` if this close caught up to it. Period must
-  be exactly `closed_through + 1` — sequence violations return 422 with structured `blockers`. Common
-  blockers: `sync_stale` (override with `allow_stale_sync=true` after manual verification),
-  `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-order).
+  `closed_through` by one, auto-advances `close_target` if this close caught up to it, and stamps the
+  period's canonical statement FactSets from the posted ledger (`statements_stamped` /
+  `stamped_statement_sets` in the response; soft-skipped with `statement_stamp_note` when reporting
+  isn't set up). Period must be exactly `closed_through + 1` — sequence violations return 422 with
+  structured `blockers`. Common blockers: `sync_stale` (override with `allow_stale_sync=true` after
+  manual verification), `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-
+  order).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -203,10 +209,13 @@ async def asyncio_detailed(
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
-  `closed_through` by one, and auto-advances `close_target` if this close caught up to it. Period must
-  be exactly `closed_through + 1` — sequence violations return 422 with structured `blockers`. Common
-  blockers: `sync_stale` (override with `allow_stale_sync=true` after manual verification),
-  `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-order).
+  `closed_through` by one, auto-advances `close_target` if this close caught up to it, and stamps the
+  period's canonical statement FactSets from the posted ledger (`statements_stamped` /
+  `stamped_statement_sets` in the response; soft-skipped with `statement_stamp_note` when reporting
+  isn't set up). Period must be exactly `closed_through + 1` — sequence violations return 422 with
+  structured `blockers`. Common blockers: `sync_stale` (override with `allow_stale_sync=true` after
+  manual verification), `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-
+  order).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -248,10 +257,13 @@ async def asyncio(
   """Close Fiscal Period
 
    Lock a single fiscal period. Posts draft entries, runs the balance-sheet equation check, advances
-  `closed_through` by one, and auto-advances `close_target` if this close caught up to it. Period must
-  be exactly `closed_through + 1` — sequence violations return 422 with structured `blockers`. Common
-  blockers: `sync_stale` (override with `allow_stale_sync=true` after manual verification),
-  `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-order).
+  `closed_through` by one, auto-advances `close_target` if this close caught up to it, and stamps the
+  period's canonical statement FactSets from the posted ledger (`statements_stamped` /
+  `stamped_statement_sets` in the response; soft-skipped with `statement_stamp_note` when reporting
+  isn't set up). Period must be exactly `closed_through + 1` — sequence violations return 422 with
+  structured `blockers`. Common blockers: `sync_stale` (override with `allow_stale_sync=true` after
+  manual verification), `period_incomplete` (draft entries unbalanced), `sequence_violation` (out-of-
+  order).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.

--- a/robosystems_client/api/extensions_robo_ledger/reopen_period.py
+++ b/robosystems_client/api/extensions_robo_ledger/reopen_period.py
@@ -114,8 +114,10 @@ def sync_detailed(
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates
-  downstream artifacts that trusted the closed state (reports, shared filings).
+  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
+  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+  sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
+  filings).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -156,8 +158,10 @@ def sync(
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates
-  downstream artifacts that trusted the closed state (reports, shared filings).
+  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
+  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+  sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
+  filings).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -193,8 +197,10 @@ async def asyncio_detailed(
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates
-  downstream artifacts that trusted the closed state (reports, shared filings).
+  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
+  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+  sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
+  filings).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -233,8 +239,10 @@ async def asyncio(
   """Reopen Fiscal Period
 
    Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). The required `reason` is captured in the audit log. Use sparingly — reopen invalidates
-  downstream artifacts that trusted the closed state (reports, shared filings).
+  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
+  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+  sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
+  filings).
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -46,6 +46,12 @@ from .close_period_response import ClosePeriodResponse
 from .close_period_response_rule_summary_type_0 import (
   ClosePeriodResponseRuleSummaryType0,
 )
+from .close_period_response_stamped_statement_sets import (
+  ClosePeriodResponseStampedStatementSets,
+)
+from .close_period_response_statement_rule_summary_type_0 import (
+  ClosePeriodResponseStatementRuleSummaryType0,
+)
 from .compute_forecast_request import ComputeForecastRequest
 from .compute_forecast_response import ComputeForecastResponse
 from .compute_metrics_request import ComputeMetricsRequest
@@ -816,6 +822,8 @@ __all__ = (
   "ClosePeriodOperation",
   "ClosePeriodResponse",
   "ClosePeriodResponseRuleSummaryType0",
+  "ClosePeriodResponseStampedStatementSets",
+  "ClosePeriodResponseStatementRuleSummaryType0",
   "ComputedMetricLite",
   "ComputeForecastRequest",
   "ComputeForecastResponse",

--- a/robosystems_client/models/close_period_response.py
+++ b/robosystems_client/models/close_period_response.py
@@ -12,6 +12,12 @@ if TYPE_CHECKING:
   from ..models.close_period_response_rule_summary_type_0 import (
     ClosePeriodResponseRuleSummaryType0,
   )
+  from ..models.close_period_response_stamped_statement_sets import (
+    ClosePeriodResponseStampedStatementSets,
+  )
+  from ..models.close_period_response_statement_rule_summary_type_0 import (
+    ClosePeriodResponseStatementRuleSummaryType0,
+  )
   from ..models.fiscal_calendar_response import FiscalCalendarResponse
 
 
@@ -33,6 +39,15 @@ class ClosePeriodResponse:
           facts in the period (auto-run on close).
       evaluated_structure_ids (list[str] | Unset): ids of schedule Structures whose rules were evaluated during the
           close. Pairs with rule_summary.
+      statements_stamped (bool | Unset): Whether the close stamped the period's canonical statement FactSets (the
+          close-time pivot). False when the tenant hasn't set up reporting yet — see statement_stamp_note. Default: False.
+      statement_stamp_note (None | str | Unset): Soft-skip reason when statements_stamped is false: no_coa_mapping |
+          no_entity | no_statement_structures | no_taxonomy.
+      stamped_statement_sets (ClosePeriodResponseStampedStatementSets | Unset): structure_id -> fact_set_id for every
+          canonical statement FactSet minted by this close (report_id NULL; replaced on reclose).
+      statement_rule_summary (ClosePeriodResponseStatementRuleSummaryType0 | None | Unset): Aggregated statement-rule
+          verification outcome across the stamped structures — keys: pass/fail/error/skipped. None when no statement rules
+          exist. Distinct from rule_summary (the schedule-rule pass).
   """
 
   fiscal_calendar: FiscalCalendarResponse
@@ -41,11 +56,20 @@ class ClosePeriodResponse:
   target_auto_advanced: bool | Unset = False
   rule_summary: ClosePeriodResponseRuleSummaryType0 | None | Unset = UNSET
   evaluated_structure_ids: list[str] | Unset = UNSET
+  statements_stamped: bool | Unset = False
+  statement_stamp_note: None | str | Unset = UNSET
+  stamped_statement_sets: ClosePeriodResponseStampedStatementSets | Unset = UNSET
+  statement_rule_summary: (
+    ClosePeriodResponseStatementRuleSummaryType0 | None | Unset
+  ) = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
     from ..models.close_period_response_rule_summary_type_0 import (
       ClosePeriodResponseRuleSummaryType0,
+    )
+    from ..models.close_period_response_statement_rule_summary_type_0 import (
+      ClosePeriodResponseStatementRuleSummaryType0,
     )
 
     fiscal_calendar = self.fiscal_calendar.to_dict()
@@ -68,6 +92,28 @@ class ClosePeriodResponse:
     if not isinstance(self.evaluated_structure_ids, Unset):
       evaluated_structure_ids = self.evaluated_structure_ids
 
+    statements_stamped = self.statements_stamped
+
+    statement_stamp_note: None | str | Unset
+    if isinstance(self.statement_stamp_note, Unset):
+      statement_stamp_note = UNSET
+    else:
+      statement_stamp_note = self.statement_stamp_note
+
+    stamped_statement_sets: dict[str, Any] | Unset = UNSET
+    if not isinstance(self.stamped_statement_sets, Unset):
+      stamped_statement_sets = self.stamped_statement_sets.to_dict()
+
+    statement_rule_summary: dict[str, Any] | None | Unset
+    if isinstance(self.statement_rule_summary, Unset):
+      statement_rule_summary = UNSET
+    elif isinstance(
+      self.statement_rule_summary, ClosePeriodResponseStatementRuleSummaryType0
+    ):
+      statement_rule_summary = self.statement_rule_summary.to_dict()
+    else:
+      statement_rule_summary = self.statement_rule_summary
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -84,6 +130,14 @@ class ClosePeriodResponse:
       field_dict["rule_summary"] = rule_summary
     if evaluated_structure_ids is not UNSET:
       field_dict["evaluated_structure_ids"] = evaluated_structure_ids
+    if statements_stamped is not UNSET:
+      field_dict["statements_stamped"] = statements_stamped
+    if statement_stamp_note is not UNSET:
+      field_dict["statement_stamp_note"] = statement_stamp_note
+    if stamped_statement_sets is not UNSET:
+      field_dict["stamped_statement_sets"] = stamped_statement_sets
+    if statement_rule_summary is not UNSET:
+      field_dict["statement_rule_summary"] = statement_rule_summary
 
     return field_dict
 
@@ -91,6 +145,12 @@ class ClosePeriodResponse:
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.close_period_response_rule_summary_type_0 import (
       ClosePeriodResponseRuleSummaryType0,
+    )
+    from ..models.close_period_response_stamped_statement_sets import (
+      ClosePeriodResponseStampedStatementSets,
+    )
+    from ..models.close_period_response_statement_rule_summary_type_0 import (
+      ClosePeriodResponseStatementRuleSummaryType0,
     )
     from ..models.fiscal_calendar_response import FiscalCalendarResponse
 
@@ -124,6 +184,51 @@ class ClosePeriodResponse:
 
     evaluated_structure_ids = cast(list[str], d.pop("evaluated_structure_ids", UNSET))
 
+    statements_stamped = d.pop("statements_stamped", UNSET)
+
+    def _parse_statement_stamp_note(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    statement_stamp_note = _parse_statement_stamp_note(
+      d.pop("statement_stamp_note", UNSET)
+    )
+
+    _stamped_statement_sets = d.pop("stamped_statement_sets", UNSET)
+    stamped_statement_sets: ClosePeriodResponseStampedStatementSets | Unset
+    if isinstance(_stamped_statement_sets, Unset):
+      stamped_statement_sets = UNSET
+    else:
+      stamped_statement_sets = ClosePeriodResponseStampedStatementSets.from_dict(
+        _stamped_statement_sets
+      )
+
+    def _parse_statement_rule_summary(
+      data: object,
+    ) -> ClosePeriodResponseStatementRuleSummaryType0 | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        statement_rule_summary_type_0 = (
+          ClosePeriodResponseStatementRuleSummaryType0.from_dict(data)
+        )
+
+        return statement_rule_summary_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(ClosePeriodResponseStatementRuleSummaryType0 | None | Unset, data)
+
+    statement_rule_summary = _parse_statement_rule_summary(
+      d.pop("statement_rule_summary", UNSET)
+    )
+
     close_period_response = cls(
       fiscal_calendar=fiscal_calendar,
       period=period,
@@ -131,6 +236,10 @@ class ClosePeriodResponse:
       target_auto_advanced=target_auto_advanced,
       rule_summary=rule_summary,
       evaluated_structure_ids=evaluated_structure_ids,
+      statements_stamped=statements_stamped,
+      statement_stamp_note=statement_stamp_note,
+      stamped_statement_sets=stamped_statement_sets,
+      statement_rule_summary=statement_rule_summary,
     )
 
     close_period_response.additional_properties = d

--- a/robosystems_client/models/close_period_response_stamped_statement_sets.py
+++ b/robosystems_client/models/close_period_response_stamped_statement_sets.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ClosePeriodResponseStampedStatementSets")
+
+
+@_attrs_define
+class ClosePeriodResponseStampedStatementSets:
+  """structure_id -> fact_set_id for every canonical statement FactSet minted by this close (report_id NULL; replaced on
+  reclose).
+
+  """
+
+  additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    close_period_response_stamped_statement_sets = cls()
+
+    close_period_response_stamped_statement_sets.additional_properties = d
+    return close_period_response_stamped_statement_sets
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> str:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: str) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/close_period_response_statement_rule_summary_type_0.py
+++ b/robosystems_client/models/close_period_response_statement_rule_summary_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ClosePeriodResponseStatementRuleSummaryType0")
+
+
+@_attrs_define
+class ClosePeriodResponseStatementRuleSummaryType0:
+  """ """
+
+  additional_properties: dict[str, int] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    close_period_response_statement_rule_summary_type_0 = cls()
+
+    close_period_response_statement_rule_summary_type_0.additional_properties = d
+    return close_period_response_statement_rule_summary_type_0
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> int:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: int) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/element_lite.py
+++ b/robosystems_client/models/element_lite.py
@@ -32,6 +32,9 @@ class ElementLite:
           period_type (None | str | Unset):
           item_type (None | str | Unset): Value-domain vocabulary (monetary | ratio | percent | multiple | days | string |
               …). None means untyped; fall back to is_monetary.
+          documentation (None | str | Unset): The element's documentation-role label — the catalog's authoritative value
+              semantics (e.g. whether a percent driver is a growth rate or a rate-on-base fraction). None when the element
+              carries no documentation label.
   """
 
   id: str
@@ -44,6 +47,7 @@ class ElementLite:
   balance_type: None | str | Unset = UNSET
   period_type: None | str | Unset = UNSET
   item_type: None | str | Unset = UNSET
+  documentation: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -87,6 +91,12 @@ class ElementLite:
     else:
       item_type = self.item_type
 
+    documentation: None | str | Unset
+    if isinstance(self.documentation, Unset):
+      documentation = UNSET
+    else:
+      documentation = self.documentation
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -110,6 +120,8 @@ class ElementLite:
       field_dict["period_type"] = period_type
     if item_type is not UNSET:
       field_dict["item_type"] = item_type
+    if documentation is not UNSET:
+      field_dict["documentation"] = documentation
 
     return field_dict
 
@@ -171,6 +183,15 @@ class ElementLite:
 
     item_type = _parse_item_type(d.pop("item_type", UNSET))
 
+    def _parse_documentation(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    documentation = _parse_documentation(d.pop("documentation", UNSET))
+
     element_lite = cls(
       id=id,
       name=name,
@@ -182,6 +203,7 @@ class ElementLite:
       balance_type=balance_type,
       period_type=period_type,
       item_type=item_type,
+      documentation=documentation,
     )
 
     element_lite.additional_properties = d

--- a/robosystems_client/models/lever_assertion_request.py
+++ b/robosystems_client/models/lever_assertion_request.py
@@ -22,13 +22,21 @@ class LeverAssertionRequest:
   """One lever's asserted values for the scenario.
 
   ``qname`` must resolve to an ``rs-driver:*`` catalog element (the
-  create handler rejects anything else). Value conventions follow the
-  catalog: percent levers are decimals per month (0.03 = 3%/month),
-  days levers are day counts.
+  create handler rejects anything else). Each lever's value semantics
+  are defined by its catalog element's documentation — surfaced as
+  ``documentation`` on the elements bundled in the forecast block's
+  envelope (``get-information-block``). Percent levers are decimals but
+  their *meaning* varies by lever: growth levers are month-over-month
+  rates (``RevenueGrowthRate`` 0.03 = +3%/month, compounding), while
+  rate-on-base levers are fractions of the same month's base
+  (``CostOfRevenueRate`` 0.62 = cost of revenue at 62% of that month's
+  revenues — not a growth rate). Days levers (``DaysSalesOutstanding``,
+  ``DaysPayableOutstanding``) are day counts.
 
   ``value`` is a uniform fill across the whole horizon;
   ``values_by_period`` overrides individual months (``"YYYY-MM"``
-  keys). At least one of the two must be provided. Months covered by
+  keys) — e.g. a margin-compression ramp asserts a different rate each
+  month. At least one of the two must be provided. Months covered by
   neither carry no assertion — the lever's rule is inactive for that
   month and its target falls to the engine's carry-forward default.
 


### PR DESCRIPTION
Regenerated Python client from the current server OpenAPI spec. Picks up already-merged server changes; **all additive, no breaking changes**.

## Changes

**Close-stamps-statements (server #922/#923)**
- `ClosePeriodResponse` gains: `statements_stamped`, `statement_stamp_note`, `stamped_statement_sets`, `statement_rule_summary`
- Two new models: `ClosePeriodResponseStampedStatementSets`, `ClosePeriodResponseStatementRuleSummaryType0`
- `reopen_period` description notes canonical-set retraction on reopen

**Forecast MCP legibility (server #924)**
- `ElementLite` gains `documentation` — the catalog element's authoritative value semantics (e.g. growth-rate vs rate-on-base fraction)
- `LeverAssertionRequest` docstring clarifies growth vs rate-on-base lever meaning

## Verification

- `just test-all` green (439 passed, ruff clean, basedpyright 0 errors)
- Pure regen output — no hand edits
- Version bump / release handled separately by the publish flow