### PR TITLE
feat(sdk): regen — forecast line assertions + plan-history backfill

### DIFF
--- a/robosystems_client/api/extensions_robo_ledger/backfill_plan_history.py
+++ b/robosystems_client/api/extensions_robo_ledger/backfill_plan_history.py
@@ -1,0 +1,288 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.backfill_plan_history_operation import BackfillPlanHistoryOperation
+from ...models.error_response import ErrorResponse
+from ...models.operation_envelope_backfill_plan_history_response import (
+  OperationEnvelopeBackfillPlanHistoryResponse,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+  graph_id: str,
+  *,
+  body: BackfillPlanHistoryOperation,
+  idempotency_key: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+  headers: dict[str, Any] = {}
+  if not isinstance(idempotency_key, Unset):
+    headers["Idempotency-Key"] = idempotency_key
+
+  _kwargs: dict[str, Any] = {
+    "method": "post",
+    "url": "/extensions/roboledger/{graph_id}/operations/backfill-plan-history".format(
+      graph_id=quote(str(graph_id), safe=""),
+    ),
+  }
+
+  _kwargs["json"] = body.to_dict()
+
+  headers["Content-Type"] = "application/json"
+
+  _kwargs["headers"] = headers
+  return _kwargs
+
+
+def _parse_response(
+  *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse | None:
+  if response.status_code == 200:
+    response_200 = OperationEnvelopeBackfillPlanHistoryResponse.from_dict(
+      response.json()
+    )
+
+    return response_200
+
+  if response.status_code == 400:
+    response_400 = ErrorResponse.from_dict(response.json())
+
+    return response_400
+
+  if response.status_code == 401:
+    response_401 = ErrorResponse.from_dict(response.json())
+
+    return response_401
+
+  if response.status_code == 403:
+    response_403 = ErrorResponse.from_dict(response.json())
+
+    return response_403
+
+  if response.status_code == 404:
+    response_404 = ErrorResponse.from_dict(response.json())
+
+    return response_404
+
+  if response.status_code == 409:
+    response_409 = ErrorResponse.from_dict(response.json())
+
+    return response_409
+
+  if response.status_code == 422:
+    response_422 = ErrorResponse.from_dict(response.json())
+
+    return response_422
+
+  if response.status_code == 429:
+    response_429 = ErrorResponse.from_dict(response.json())
+
+    return response_429
+
+  if response.status_code == 500:
+    response_500 = ErrorResponse.from_dict(response.json())
+
+    return response_500
+
+  if client.raise_on_unexpected_status:
+    raise errors.UnexpectedStatus(response.status_code, response.content)
+  else:
+    return None
+
+
+def _build_response(
+  *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse]:
+  return Response(
+    status_code=HTTPStatus(response.status_code),
+    content=response.content,
+    headers=response.headers,
+    parsed=_parse_response(client=client, response=response),
+  )
+
+
+def sync_detailed(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BackfillPlanHistoryOperation,
+  idempotency_key: None | str | Unset = UNSET,
+) -> Response[ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse]:
+  """Backfill Plan History
+
+   Compile monthly statement history behind the close boundary — the plan's historical columns. Seeds
+  any missing FiscalPeriod rows (baseline-closed) back to the clamped `start_period`, then restamps
+  each month lacking canonical statement FactSets by running the real reopen → reclose cycle (balance
+  validation, statement rules, and audit events per month). Chunked: at most `max_periods` months per
+  call, oldest first — loop until `remaining_periods` comes back empty. Idempotent: already-stamped
+  months are never touched. Months holding draft entries are skipped, never posted. `start_period` is
+  clamped to the earliest month with ledger data, so deep-history tenants only backfill what actually
+  exists.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BackfillPlanHistoryOperation): Compile monthly statement history behind the close
+          boundary.
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      Response[ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse]
+  """
+
+  kwargs = _get_kwargs(
+    graph_id=graph_id,
+    body=body,
+    idempotency_key=idempotency_key,
+  )
+
+  response = client.get_httpx_client().request(
+    **kwargs,
+  )
+
+  return _build_response(client=client, response=response)
+
+
+def sync(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BackfillPlanHistoryOperation,
+  idempotency_key: None | str | Unset = UNSET,
+) -> ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse | None:
+  """Backfill Plan History
+
+   Compile monthly statement history behind the close boundary — the plan's historical columns. Seeds
+  any missing FiscalPeriod rows (baseline-closed) back to the clamped `start_period`, then restamps
+  each month lacking canonical statement FactSets by running the real reopen → reclose cycle (balance
+  validation, statement rules, and audit events per month). Chunked: at most `max_periods` months per
+  call, oldest first — loop until `remaining_periods` comes back empty. Idempotent: already-stamped
+  months are never touched. Months holding draft entries are skipped, never posted. `start_period` is
+  clamped to the earliest month with ledger data, so deep-history tenants only backfill what actually
+  exists.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BackfillPlanHistoryOperation): Compile monthly statement history behind the close
+          boundary.
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse
+  """
+
+  return sync_detailed(
+    graph_id=graph_id,
+    client=client,
+    body=body,
+    idempotency_key=idempotency_key,
+  ).parsed
+
+
+async def asyncio_detailed(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BackfillPlanHistoryOperation,
+  idempotency_key: None | str | Unset = UNSET,
+) -> Response[ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse]:
+  """Backfill Plan History
+
+   Compile monthly statement history behind the close boundary — the plan's historical columns. Seeds
+  any missing FiscalPeriod rows (baseline-closed) back to the clamped `start_period`, then restamps
+  each month lacking canonical statement FactSets by running the real reopen → reclose cycle (balance
+  validation, statement rules, and audit events per month). Chunked: at most `max_periods` months per
+  call, oldest first — loop until `remaining_periods` comes back empty. Idempotent: already-stamped
+  months are never touched. Months holding draft entries are skipped, never posted. `start_period` is
+  clamped to the earliest month with ledger data, so deep-history tenants only backfill what actually
+  exists.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BackfillPlanHistoryOperation): Compile monthly statement history behind the close
+          boundary.
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      Response[ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse]
+  """
+
+  kwargs = _get_kwargs(
+    graph_id=graph_id,
+    body=body,
+    idempotency_key=idempotency_key,
+  )
+
+  response = await client.get_async_httpx_client().request(**kwargs)
+
+  return _build_response(client=client, response=response)
+
+
+async def asyncio(
+  graph_id: str,
+  *,
+  client: AuthenticatedClient,
+  body: BackfillPlanHistoryOperation,
+  idempotency_key: None | str | Unset = UNSET,
+) -> ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse | None:
+  """Backfill Plan History
+
+   Compile monthly statement history behind the close boundary — the plan's historical columns. Seeds
+  any missing FiscalPeriod rows (baseline-closed) back to the clamped `start_period`, then restamps
+  each month lacking canonical statement FactSets by running the real reopen → reclose cycle (balance
+  validation, statement rules, and audit events per month). Chunked: at most `max_periods` months per
+  call, oldest first — loop until `remaining_periods` comes back empty. Idempotent: already-stamped
+  months are never touched. Months holding draft entries are skipped, never posted. `start_period` is
+  clamped to the earliest month with ledger data, so deep-history tenants only backfill what actually
+  exists.
+
+  **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
+  return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
+
+  Args:
+      graph_id (str):
+      idempotency_key (None | str | Unset):
+      body (BackfillPlanHistoryOperation): Compile monthly statement history behind the close
+          boundary.
+
+  Raises:
+      errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+      httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+  Returns:
+      ErrorResponse | OperationEnvelopeBackfillPlanHistoryResponse
+  """
+
+  return (
+    await asyncio_detailed(
+      graph_id=graph_id,
+      client=client,
+      body=body,
+      idempotency_key=idempotency_key,
+    )
+  ).parsed

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -15,6 +15,12 @@ from .auto_map_elements_operation import AutoMapElementsOperation
 from .available_extension import AvailableExtension
 from .available_extensions_response import AvailableExtensionsResponse
 from .available_graph_tiers_response import AvailableGraphTiersResponse
+from .backfill_period_outcome import BackfillPeriodOutcome
+from .backfill_period_outcome_statement_rule_summary_type_0 import (
+  BackfillPeriodOutcomeStatementRuleSummaryType0,
+)
+from .backfill_plan_history_operation import BackfillPlanHistoryOperation
+from .backfill_plan_history_response import BackfillPlanHistoryResponse
 from .backup_create_request import BackupCreateRequest
 from .backup_download_url_response import BackupDownloadUrlResponse
 from .backup_limits import BackupLimits
@@ -287,6 +293,12 @@ from .lever_assertion_request import LeverAssertionRequest
 from .lever_assertion_request_values_by_period_type_0 import (
   LeverAssertionRequestValuesByPeriodType0,
 )
+from .line_assertion_lite import LineAssertionLite
+from .line_assertion_lite_values_by_period import LineAssertionLiteValuesByPeriod
+from .line_assertion_request import LineAssertionRequest
+from .line_assertion_request_values_by_period_type_0 import (
+  LineAssertionRequestValuesByPeriodType0,
+)
 from .line_item_metadata_predicate import LineItemMetadataPredicate
 from .link_entity_taxonomy_request import LinkEntityTaxonomyRequest
 from .link_entity_taxonomy_request_basis import LinkEntityTaxonomyRequestBasis
@@ -326,6 +338,12 @@ from .operation_envelope_association_response import (
 )
 from .operation_envelope_association_response_status import (
   OperationEnvelopeAssociationResponseStatus,
+)
+from .operation_envelope_backfill_plan_history_response import (
+  OperationEnvelopeBackfillPlanHistoryResponse,
+)
+from .operation_envelope_backfill_plan_history_response_status import (
+  OperationEnvelopeBackfillPlanHistoryResponseStatus,
 )
 from .operation_envelope_bind_text_block_response import (
   OperationEnvelopeBindTextBlockResponse,
@@ -795,6 +813,10 @@ __all__ = (
   "AvailableExtension",
   "AvailableExtensionsResponse",
   "AvailableGraphTiersResponse",
+  "BackfillPeriodOutcome",
+  "BackfillPeriodOutcomeStatementRuleSummaryType0",
+  "BackfillPlanHistoryOperation",
+  "BackfillPlanHistoryResponse",
   "BackupCreateRequest",
   "BackupDownloadUrlResponse",
   "BackupLimits",
@@ -1017,6 +1039,10 @@ __all__ = (
   "LeverAssertionLiteValuesByPeriod",
   "LeverAssertionRequest",
   "LeverAssertionRequestValuesByPeriodType0",
+  "LineAssertionLite",
+  "LineAssertionLiteValuesByPeriod",
+  "LineAssertionRequest",
+  "LineAssertionRequestValuesByPeriodType0",
   "LineItemMetadataPredicate",
   "LinkEntityTaxonomyRequest",
   "LinkEntityTaxonomyRequestBasis",
@@ -1049,6 +1075,8 @@ __all__ = (
   "OperationEnvelope",
   "OperationEnvelopeAssociationResponse",
   "OperationEnvelopeAssociationResponseStatus",
+  "OperationEnvelopeBackfillPlanHistoryResponse",
+  "OperationEnvelopeBackfillPlanHistoryResponseStatus",
   "OperationEnvelopeBindTextBlockResponse",
   "OperationEnvelopeBindTextBlockResponseStatus",
   "OperationEnvelopeChangeReportingStyleResponse",

--- a/robosystems_client/models/backfill_period_outcome.py
+++ b/robosystems_client/models/backfill_period_outcome.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.backfill_period_outcome_statement_rule_summary_type_0 import (
+    BackfillPeriodOutcomeStatementRuleSummaryType0,
+  )
+
+
+T = TypeVar("T", bound="BackfillPeriodOutcome")
+
+
+@_attrs_define
+class BackfillPeriodOutcome:
+  """Per-month result of a plan-history backfill pass.
+
+  Attributes:
+      period (str): The month, in YYYY-MM
+      status (str): stamped: reopen → reclose completed. skipped_drafts: the month holds draft entries the backfill
+          refuses to post — review via list-period-drafts, then close-period or re-run. failed: the reclose raised;
+          processing halted (see detail).
+      statements_stamped (bool | Unset): Whether the reclose stamped canonical statement FactSets. False with a
+          statement_stamp_note soft-skip when reporting isn't set up. Default: False.
+      statement_stamp_note (None | str | Unset): Soft-skip reason when statements_stamped is false
+      statement_rule_summary (BackfillPeriodOutcomeStatementRuleSummaryType0 | None | Unset): Statement-rule
+          verification tally for the month's stamped sets (pass/fail/error/skipped); None when no rules ran.
+      detail (None | str | Unset): Human-readable detail for skipped/failed months
+  """
+
+  period: str
+  status: str
+  statements_stamped: bool | Unset = False
+  statement_stamp_note: None | str | Unset = UNSET
+  statement_rule_summary: (
+    BackfillPeriodOutcomeStatementRuleSummaryType0 | None | Unset
+  ) = UNSET
+  detail: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.backfill_period_outcome_statement_rule_summary_type_0 import (
+      BackfillPeriodOutcomeStatementRuleSummaryType0,
+    )
+
+    period = self.period
+
+    status = self.status
+
+    statements_stamped = self.statements_stamped
+
+    statement_stamp_note: None | str | Unset
+    if isinstance(self.statement_stamp_note, Unset):
+      statement_stamp_note = UNSET
+    else:
+      statement_stamp_note = self.statement_stamp_note
+
+    statement_rule_summary: dict[str, Any] | None | Unset
+    if isinstance(self.statement_rule_summary, Unset):
+      statement_rule_summary = UNSET
+    elif isinstance(
+      self.statement_rule_summary, BackfillPeriodOutcomeStatementRuleSummaryType0
+    ):
+      statement_rule_summary = self.statement_rule_summary.to_dict()
+    else:
+      statement_rule_summary = self.statement_rule_summary
+
+    detail: None | str | Unset
+    if isinstance(self.detail, Unset):
+      detail = UNSET
+    else:
+      detail = self.detail
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "period": period,
+        "status": status,
+      }
+    )
+    if statements_stamped is not UNSET:
+      field_dict["statements_stamped"] = statements_stamped
+    if statement_stamp_note is not UNSET:
+      field_dict["statement_stamp_note"] = statement_stamp_note
+    if statement_rule_summary is not UNSET:
+      field_dict["statement_rule_summary"] = statement_rule_summary
+    if detail is not UNSET:
+      field_dict["detail"] = detail
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.backfill_period_outcome_statement_rule_summary_type_0 import (
+      BackfillPeriodOutcomeStatementRuleSummaryType0,
+    )
+
+    d = dict(src_dict)
+    period = d.pop("period")
+
+    status = d.pop("status")
+
+    statements_stamped = d.pop("statements_stamped", UNSET)
+
+    def _parse_statement_stamp_note(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    statement_stamp_note = _parse_statement_stamp_note(
+      d.pop("statement_stamp_note", UNSET)
+    )
+
+    def _parse_statement_rule_summary(
+      data: object,
+    ) -> BackfillPeriodOutcomeStatementRuleSummaryType0 | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        statement_rule_summary_type_0 = (
+          BackfillPeriodOutcomeStatementRuleSummaryType0.from_dict(data)
+        )
+
+        return statement_rule_summary_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(BackfillPeriodOutcomeStatementRuleSummaryType0 | None | Unset, data)
+
+    statement_rule_summary = _parse_statement_rule_summary(
+      d.pop("statement_rule_summary", UNSET)
+    )
+
+    def _parse_detail(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    detail = _parse_detail(d.pop("detail", UNSET))
+
+    backfill_period_outcome = cls(
+      period=period,
+      status=status,
+      statements_stamped=statements_stamped,
+      statement_stamp_note=statement_stamp_note,
+      statement_rule_summary=statement_rule_summary,
+      detail=detail,
+    )
+
+    backfill_period_outcome.additional_properties = d
+    return backfill_period_outcome
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/backfill_period_outcome_statement_rule_summary_type_0.py
+++ b/robosystems_client/models/backfill_period_outcome_statement_rule_summary_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="BackfillPeriodOutcomeStatementRuleSummaryType0")
+
+
+@_attrs_define
+class BackfillPeriodOutcomeStatementRuleSummaryType0:
+  """ """
+
+  additional_properties: dict[str, int] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    backfill_period_outcome_statement_rule_summary_type_0 = cls()
+
+    backfill_period_outcome_statement_rule_summary_type_0.additional_properties = d
+    return backfill_period_outcome_statement_rule_summary_type_0
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> int:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: int) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/backfill_plan_history_operation.py
+++ b/robosystems_client/models/backfill_plan_history_operation.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="BackfillPlanHistoryOperation")
+
+
+@_attrs_define
+class BackfillPlanHistoryOperation:
+  """Compile monthly statement history behind the close boundary.
+
+  Attributes:
+      start_period (None | str | Unset): YYYY-MM period to backfill from. Clamped to the earliest month with ledger
+          data; defaults to that month when omitted. Must be on or before `closed_through`.
+      max_periods (int | Unset): Maximum months to restamp in this call. Each month runs a full reopen → reclose
+          cycle; keep chunks modest and loop on `remaining_periods`. Default: 12.
+      allow_stale_sync (bool | Unset): Override the sync-currency gate on each reclose. Historical months predate the
+          last sync in the normal case, so this is rarely needed. Default: False.
+      note (None | str | Unset): Free-form note attached to each close audit event
+  """
+
+  start_period: None | str | Unset = UNSET
+  max_periods: int | Unset = 12
+  allow_stale_sync: bool | Unset = False
+  note: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    start_period: None | str | Unset
+    if isinstance(self.start_period, Unset):
+      start_period = UNSET
+    else:
+      start_period = self.start_period
+
+    max_periods = self.max_periods
+
+    allow_stale_sync = self.allow_stale_sync
+
+    note: None | str | Unset
+    if isinstance(self.note, Unset):
+      note = UNSET
+    else:
+      note = self.note
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update({})
+    if start_period is not UNSET:
+      field_dict["start_period"] = start_period
+    if max_periods is not UNSET:
+      field_dict["max_periods"] = max_periods
+    if allow_stale_sync is not UNSET:
+      field_dict["allow_stale_sync"] = allow_stale_sync
+    if note is not UNSET:
+      field_dict["note"] = note
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+
+    def _parse_start_period(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    start_period = _parse_start_period(d.pop("start_period", UNSET))
+
+    max_periods = d.pop("max_periods", UNSET)
+
+    allow_stale_sync = d.pop("allow_stale_sync", UNSET)
+
+    def _parse_note(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    note = _parse_note(d.pop("note", UNSET))
+
+    backfill_plan_history_operation = cls(
+      start_period=start_period,
+      max_periods=max_periods,
+      allow_stale_sync=allow_stale_sync,
+      note=note,
+    )
+
+    backfill_plan_history_operation.additional_properties = d
+    return backfill_plan_history_operation
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/backfill_plan_history_response.py
+++ b/robosystems_client/models/backfill_plan_history_response.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.backfill_period_outcome import BackfillPeriodOutcome
+  from ..models.fiscal_calendar_response import FiscalCalendarResponse
+
+
+T = TypeVar("T", bound="BackfillPlanHistoryResponse")
+
+
+@_attrs_define
+class BackfillPlanHistoryResponse:
+  """Response from one chunked plan-history backfill call.
+
+  Attributes:
+      fiscal_calendar (FiscalCalendarResponse): Current fiscal calendar state for a graph.
+      earliest_available_period (str): First month with ledger data — the hard floor for backfill
+      effective_start_period (str): The start actually used after clamping to earliest_available_period
+      closed_through (str): The close boundary the backfill runs up to (inclusive)
+      period_rows_created (int | Unset): FiscalPeriod rows seeded (baseline-closed) for months the calendar didn't
+          cover yet Default: 0.
+      processed (list[BackfillPeriodOutcome] | Unset): Months this call attempted, oldest first
+      remaining_periods (list[str] | Unset): Months still lacking canonical statement sets that this call did not
+          attempt (beyond max_periods, or after a failure halt). Loop until empty.
+  """
+
+  fiscal_calendar: FiscalCalendarResponse
+  earliest_available_period: str
+  effective_start_period: str
+  closed_through: str
+  period_rows_created: int | Unset = 0
+  processed: list[BackfillPeriodOutcome] | Unset = UNSET
+  remaining_periods: list[str] | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    fiscal_calendar = self.fiscal_calendar.to_dict()
+
+    earliest_available_period = self.earliest_available_period
+
+    effective_start_period = self.effective_start_period
+
+    closed_through = self.closed_through
+
+    period_rows_created = self.period_rows_created
+
+    processed: list[dict[str, Any]] | Unset = UNSET
+    if not isinstance(self.processed, Unset):
+      processed = []
+      for processed_item_data in self.processed:
+        processed_item = processed_item_data.to_dict()
+        processed.append(processed_item)
+
+    remaining_periods: list[str] | Unset = UNSET
+    if not isinstance(self.remaining_periods, Unset):
+      remaining_periods = self.remaining_periods
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "fiscal_calendar": fiscal_calendar,
+        "earliest_available_period": earliest_available_period,
+        "effective_start_period": effective_start_period,
+        "closed_through": closed_through,
+      }
+    )
+    if period_rows_created is not UNSET:
+      field_dict["period_rows_created"] = period_rows_created
+    if processed is not UNSET:
+      field_dict["processed"] = processed
+    if remaining_periods is not UNSET:
+      field_dict["remaining_periods"] = remaining_periods
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.backfill_period_outcome import BackfillPeriodOutcome
+    from ..models.fiscal_calendar_response import FiscalCalendarResponse
+
+    d = dict(src_dict)
+    fiscal_calendar = FiscalCalendarResponse.from_dict(d.pop("fiscal_calendar"))
+
+    earliest_available_period = d.pop("earliest_available_period")
+
+    effective_start_period = d.pop("effective_start_period")
+
+    closed_through = d.pop("closed_through")
+
+    period_rows_created = d.pop("period_rows_created", UNSET)
+
+    _processed = d.pop("processed", UNSET)
+    processed: list[BackfillPeriodOutcome] | Unset = UNSET
+    if _processed is not UNSET:
+      processed = []
+      for processed_item_data in _processed:
+        processed_item = BackfillPeriodOutcome.from_dict(processed_item_data)
+
+        processed.append(processed_item)
+
+    remaining_periods = cast(list[str], d.pop("remaining_periods", UNSET))
+
+    backfill_plan_history_response = cls(
+      fiscal_calendar=fiscal_calendar,
+      earliest_available_period=earliest_available_period,
+      effective_start_period=effective_start_period,
+      closed_through=closed_through,
+      period_rows_created=period_rows_created,
+      processed=processed,
+      remaining_periods=remaining_periods,
+    )
+
+    backfill_plan_history_response.additional_properties = d
+    return backfill_plan_history_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/create_forecast_request.py
+++ b/robosystems_client/models/create_forecast_request.py
@@ -13,6 +13,7 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
   from ..models.lever_assertion_request import LeverAssertionRequest
+  from ..models.line_assertion_request import LineAssertionRequest
 
 
 T = TypeVar("T", bound="CreateForecastRequest")
@@ -37,6 +38,8 @@ class CreateForecastRequest:
           base_period (None | str | Unset): Seed month (``YYYY-MM``) the walk projects forward from. Defaults to the
               fiscal calendar's closed-through period, else the newest actual report month. Resolved and stored at create
               time.
+          line_assertions (list[LineAssertionRequest] | Unset): Direct statement-line assertions (manual overrides). Each
+              names a calc-DAG leaf and wins over driver rules and carry-forward for the months it asserts.
           entity_id (None | str | Unset): Entity the scenario belongs to. Defaults to the graph's earliest-created entity
               (single-entity convention).
   """
@@ -48,6 +51,7 @@ class CreateForecastRequest:
   )
   horizon_months: int | Unset = 12
   base_period: None | str | Unset = UNSET
+  line_assertions: list[LineAssertionRequest] | Unset = UNSET
   entity_id: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -71,6 +75,13 @@ class CreateForecastRequest:
     else:
       base_period = self.base_period
 
+    line_assertions: list[dict[str, Any]] | Unset = UNSET
+    if not isinstance(self.line_assertions, Unset):
+      line_assertions = []
+      for line_assertions_item_data in self.line_assertions:
+        line_assertions_item = line_assertions_item_data.to_dict()
+        line_assertions.append(line_assertions_item)
+
     entity_id: None | str | Unset
     if isinstance(self.entity_id, Unset):
       entity_id = UNSET
@@ -91,6 +102,8 @@ class CreateForecastRequest:
       field_dict["horizon_months"] = horizon_months
     if base_period is not UNSET:
       field_dict["base_period"] = base_period
+    if line_assertions is not UNSET:
+      field_dict["line_assertions"] = line_assertions
     if entity_id is not UNSET:
       field_dict["entity_id"] = entity_id
 
@@ -99,6 +112,7 @@ class CreateForecastRequest:
   @classmethod
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.lever_assertion_request import LeverAssertionRequest
+    from ..models.line_assertion_request import LineAssertionRequest
 
     d = dict(src_dict)
     name = d.pop("name")
@@ -128,6 +142,15 @@ class CreateForecastRequest:
 
     base_period = _parse_base_period(d.pop("base_period", UNSET))
 
+    _line_assertions = d.pop("line_assertions", UNSET)
+    line_assertions: list[LineAssertionRequest] | Unset = UNSET
+    if _line_assertions is not UNSET:
+      line_assertions = []
+      for line_assertions_item_data in _line_assertions:
+        line_assertions_item = LineAssertionRequest.from_dict(line_assertions_item_data)
+
+        line_assertions.append(line_assertions_item)
+
     def _parse_entity_id(data: object) -> None | str | Unset:
       if data is None:
         return data
@@ -143,6 +166,7 @@ class CreateForecastRequest:
       scenario_kind=scenario_kind,
       horizon_months=horizon_months,
       base_period=base_period,
+      line_assertions=line_assertions,
       entity_id=entity_id,
     )
 

--- a/robosystems_client/models/forecast_mechanics.py
+++ b/robosystems_client/models/forecast_mechanics.py
@@ -11,6 +11,7 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
   from ..models.lever_assertion_lite import LeverAssertionLite
+  from ..models.line_assertion_lite import LineAssertionLite
 
 
 T = TypeVar("T", bound="ForecastMechanics")
@@ -38,6 +39,8 @@ class ForecastMechanics:
           kind (Literal['forecast'] | Unset):  Default: 'forecast'.
           scenario_kind (ForecastMechanicsScenarioKind | Unset): Scenario kind — display/filter metadata, not machinery.
               Default: ForecastMechanicsScenarioKind.FORECAST.
+          line_assertions (list[LineAssertionLite] | Unset): Direct statement-line assertions (authoring order) — manual
+              overrides that win over driver rules and carry-forward for the months they name.
           computed_months (int | Unset): Number of forward months with computed scenario FactSets. Runtime state filled at
               envelope-build time — 0 until the first compute-forecast run. Default: 0.
   """
@@ -49,6 +52,7 @@ class ForecastMechanics:
   scenario_kind: ForecastMechanicsScenarioKind | Unset = (
     ForecastMechanicsScenarioKind.FORECAST
   )
+  line_assertions: list[LineAssertionLite] | Unset = UNSET
   computed_months: int | Unset = 0
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -68,6 +72,13 @@ class ForecastMechanics:
     if not isinstance(self.scenario_kind, Unset):
       scenario_kind = self.scenario_kind.value
 
+    line_assertions: list[dict[str, Any]] | Unset = UNSET
+    if not isinstance(self.line_assertions, Unset):
+      line_assertions = []
+      for line_assertions_item_data in self.line_assertions:
+        line_assertions_item = line_assertions_item_data.to_dict()
+        line_assertions.append(line_assertions_item)
+
     computed_months = self.computed_months
 
     field_dict: dict[str, Any] = {}
@@ -83,6 +94,8 @@ class ForecastMechanics:
       field_dict["kind"] = kind
     if scenario_kind is not UNSET:
       field_dict["scenario_kind"] = scenario_kind
+    if line_assertions is not UNSET:
+      field_dict["line_assertions"] = line_assertions
     if computed_months is not UNSET:
       field_dict["computed_months"] = computed_months
 
@@ -91,6 +104,7 @@ class ForecastMechanics:
   @classmethod
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.lever_assertion_lite import LeverAssertionLite
+    from ..models.line_assertion_lite import LineAssertionLite
 
     d = dict(src_dict)
     horizon_months = d.pop("horizon_months")
@@ -115,6 +129,15 @@ class ForecastMechanics:
     else:
       scenario_kind = ForecastMechanicsScenarioKind(_scenario_kind)
 
+    _line_assertions = d.pop("line_assertions", UNSET)
+    line_assertions: list[LineAssertionLite] | Unset = UNSET
+    if _line_assertions is not UNSET:
+      line_assertions = []
+      for line_assertions_item_data in _line_assertions:
+        line_assertions_item = LineAssertionLite.from_dict(line_assertions_item_data)
+
+        line_assertions.append(line_assertions_item)
+
     computed_months = d.pop("computed_months", UNSET)
 
     forecast_mechanics = cls(
@@ -123,6 +146,7 @@ class ForecastMechanics:
       levers=levers,
       kind=kind,
       scenario_kind=scenario_kind,
+      line_assertions=line_assertions,
       computed_months=computed_months,
     )
 

--- a/robosystems_client/models/line_assertion_lite.py
+++ b/robosystems_client/models/line_assertion_lite.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.line_assertion_lite_values_by_period import (
+    LineAssertionLiteValuesByPeriod,
+  )
+
+
+T = TypeVar("T", bound="LineAssertionLite")
+
+
+@_attrs_define
+class LineAssertionLite:
+  """One statement line's persisted direct assertion inside
+  ``ForecastMechanics``.
+
+  The manual-override sibling of :class:`LeverAssertionLite`: a lever
+  asserts a *driver* whose rule derives a line; a line assertion pins
+  the **line itself** (a calc-DAG leaf) to typed values for the months
+  it names — winning over driver rules and carry-forward for exactly
+  those months (a displaced rule surfaces in the compute response's
+  ``skipped`` list). Subtotals stay calc-DAG-derived, so a manual line
+  still articulates through RollUps, RE, balancing cash, and derived
+  CF, and stays verification-gated.
+
+  Same persistence doctrine as levers: values are duplicated as
+  authored facts in the scenario's lever FactSet (facts are what
+  ``compute-forecast`` binds); this mechanics copy is the
+  operator-legible round-trip shape.
+
+      Attributes:
+          qname (str): Asserted statement-leaf qname.
+          element_id (str): Resolved tenant element id.
+          values_by_period (LineAssertionLiteValuesByPeriod): Expanded per-month assertions keyed by ``YYYY-MM``.
+          item_type (None | str | Unset): Format family from the element (monetary | ...).
+          period_type (str | Unset): The element's period type — duration assertions pin IS lines; instant assertions pin
+              BS lines through the roll. Default: 'duration'.
+  """
+
+  qname: str
+  element_id: str
+  values_by_period: LineAssertionLiteValuesByPeriod
+  item_type: None | str | Unset = UNSET
+  period_type: str | Unset = "duration"
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    qname = self.qname
+
+    element_id = self.element_id
+
+    values_by_period = self.values_by_period.to_dict()
+
+    item_type: None | str | Unset
+    if isinstance(self.item_type, Unset):
+      item_type = UNSET
+    else:
+      item_type = self.item_type
+
+    period_type = self.period_type
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "qname": qname,
+        "element_id": element_id,
+        "values_by_period": values_by_period,
+      }
+    )
+    if item_type is not UNSET:
+      field_dict["item_type"] = item_type
+    if period_type is not UNSET:
+      field_dict["period_type"] = period_type
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.line_assertion_lite_values_by_period import (
+      LineAssertionLiteValuesByPeriod,
+    )
+
+    d = dict(src_dict)
+    qname = d.pop("qname")
+
+    element_id = d.pop("element_id")
+
+    values_by_period = LineAssertionLiteValuesByPeriod.from_dict(
+      d.pop("values_by_period")
+    )
+
+    def _parse_item_type(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    item_type = _parse_item_type(d.pop("item_type", UNSET))
+
+    period_type = d.pop("period_type", UNSET)
+
+    line_assertion_lite = cls(
+      qname=qname,
+      element_id=element_id,
+      values_by_period=values_by_period,
+      item_type=item_type,
+      period_type=period_type,
+    )
+
+    line_assertion_lite.additional_properties = d
+    return line_assertion_lite
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/line_assertion_lite_values_by_period.py
+++ b/robosystems_client/models/line_assertion_lite_values_by_period.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="LineAssertionLiteValuesByPeriod")
+
+
+@_attrs_define
+class LineAssertionLiteValuesByPeriod:
+  """Expanded per-month assertions keyed by ``YYYY-MM``."""
+
+  additional_properties: dict[str, float] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    line_assertion_lite_values_by_period = cls()
+
+    line_assertion_lite_values_by_period.additional_properties = d
+    return line_assertion_lite_values_by_period
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> float:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: float) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/line_assertion_request.py
+++ b/robosystems_client/models/line_assertion_request.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.line_assertion_request_values_by_period_type_0 import (
+    LineAssertionRequestValuesByPeriodType0,
+  )
+
+
+T = TypeVar("T", bound="LineAssertionRequest")
+
+
+@_attrs_define
+class LineAssertionRequest:
+  """One statement line's directly asserted values for the scenario.
+
+  The manual-override half of the authored surface: where a lever
+  asserts a *driver* (growth %, DSO) whose rule derives the line, a
+  line assertion asserts the **line itself** — an rs-gaap (or tenant
+  extension) statement leaf pinned to typed values for the months it
+  names. Assertions win over driver rules and carry-forward for those
+  months (a displaced rule lands in ``skipped``, legibly); months the
+  assertion doesn't name keep the engine's normal derivation.
+
+  **Leaves only** — subtotals stay calc-DAG-derived, so a manually set
+  line still articulates through RollUps, RE, balancing cash, and the
+  derived CF, and stays verification-gated (the whole pitch vs a
+  spreadsheet cell). The create handler rejects calc-parent qnames.
+
+  Value/period grammar is identical to levers: ``value`` is a uniform
+  fill across the horizon, ``values_by_period`` overrides individual
+  months. The canonical uses: zero out a base-month one-off so
+  carry-forward stops replicating it, or hold a line at a known budget
+  number no driver models.
+
+      Attributes:
+          qname (str): QName of the statement leaf to assert (e.g. ``rs-gaap:NonoperatingIncomeExpense``). Must be a calc-
+              DAG leaf; rs-driver concepts belong in ``levers``.
+          value (float | None | Unset): Uniform value asserted for every month of the horizon.
+          values_by_period (LineAssertionRequestValuesByPeriodType0 | None | Unset): Per-month overrides keyed by ``YYYY-
+              MM``. Wins over ``value`` for the months it names.
+  """
+
+  qname: str
+  value: float | None | Unset = UNSET
+  values_by_period: LineAssertionRequestValuesByPeriodType0 | None | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.line_assertion_request_values_by_period_type_0 import (
+      LineAssertionRequestValuesByPeriodType0,
+    )
+
+    qname = self.qname
+
+    value: float | None | Unset
+    if isinstance(self.value, Unset):
+      value = UNSET
+    else:
+      value = self.value
+
+    values_by_period: dict[str, Any] | None | Unset
+    if isinstance(self.values_by_period, Unset):
+      values_by_period = UNSET
+    elif isinstance(self.values_by_period, LineAssertionRequestValuesByPeriodType0):
+      values_by_period = self.values_by_period.to_dict()
+    else:
+      values_by_period = self.values_by_period
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "qname": qname,
+      }
+    )
+    if value is not UNSET:
+      field_dict["value"] = value
+    if values_by_period is not UNSET:
+      field_dict["values_by_period"] = values_by_period
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.line_assertion_request_values_by_period_type_0 import (
+      LineAssertionRequestValuesByPeriodType0,
+    )
+
+    d = dict(src_dict)
+    qname = d.pop("qname")
+
+    def _parse_value(data: object) -> float | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(float | None | Unset, data)
+
+    value = _parse_value(d.pop("value", UNSET))
+
+    def _parse_values_by_period(
+      data: object,
+    ) -> LineAssertionRequestValuesByPeriodType0 | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        values_by_period_type_0 = LineAssertionRequestValuesByPeriodType0.from_dict(
+          data
+        )
+
+        return values_by_period_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(LineAssertionRequestValuesByPeriodType0 | None | Unset, data)
+
+    values_by_period = _parse_values_by_period(d.pop("values_by_period", UNSET))
+
+    line_assertion_request = cls(
+      qname=qname,
+      value=value,
+      values_by_period=values_by_period,
+    )
+
+    line_assertion_request.additional_properties = d
+    return line_assertion_request
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/line_assertion_request_values_by_period_type_0.py
+++ b/robosystems_client/models/line_assertion_request_values_by_period_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="LineAssertionRequestValuesByPeriodType0")
+
+
+@_attrs_define
+class LineAssertionRequestValuesByPeriodType0:
+  """ """
+
+  additional_properties: dict[str, float] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    line_assertion_request_values_by_period_type_0 = cls()
+
+    line_assertion_request_values_by_period_type_0.additional_properties = d
+    return line_assertion_request_values_by_period_type_0
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> float:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: float) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_backfill_plan_history_response.py
+++ b/robosystems_client/models/operation_envelope_backfill_plan_history_response.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.operation_envelope_backfill_plan_history_response_status import (
+  OperationEnvelopeBackfillPlanHistoryResponseStatus,
+)
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.backfill_plan_history_response import BackfillPlanHistoryResponse
+
+
+T = TypeVar("T", bound="OperationEnvelopeBackfillPlanHistoryResponse")
+
+
+@_attrs_define
+class OperationEnvelopeBackfillPlanHistoryResponse:
+  """
+  Attributes:
+      operation (str): Kebab-case operation name
+      operation_id (str): op_-prefixed ULID for audit and SSE correlation
+      status (OperationEnvelopeBackfillPlanHistoryResponseStatus): Operation lifecycle state
+      at (str): ISO-8601 UTC timestamp
+      result (BackfillPlanHistoryResponse | None | Unset): Command-specific result payload
+      created_by (None | str | Unset): User ID that initiated the operation (null for legacy callers)
+      idempotent_replay (bool | Unset): True when this envelope came from the idempotency cache — the underlying
+          command did not execute again. False on fresh executions. Default: False.
+  """
+
+  operation: str
+  operation_id: str
+  status: OperationEnvelopeBackfillPlanHistoryResponseStatus
+  at: str
+  result: BackfillPlanHistoryResponse | None | Unset = UNSET
+  created_by: None | str | Unset = UNSET
+  idempotent_replay: bool | Unset = False
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.backfill_plan_history_response import BackfillPlanHistoryResponse
+
+    operation = self.operation
+
+    operation_id = self.operation_id
+
+    status = self.status.value
+
+    at = self.at
+
+    result: dict[str, Any] | None | Unset
+    if isinstance(self.result, Unset):
+      result = UNSET
+    elif isinstance(self.result, BackfillPlanHistoryResponse):
+      result = self.result.to_dict()
+    else:
+      result = self.result
+
+    created_by: None | str | Unset
+    if isinstance(self.created_by, Unset):
+      created_by = UNSET
+    else:
+      created_by = self.created_by
+
+    idempotent_replay = self.idempotent_replay
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "operation": operation,
+        "operationId": operation_id,
+        "status": status,
+        "at": at,
+      }
+    )
+    if result is not UNSET:
+      field_dict["result"] = result
+    if created_by is not UNSET:
+      field_dict["createdBy"] = created_by
+    if idempotent_replay is not UNSET:
+      field_dict["idempotentReplay"] = idempotent_replay
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.backfill_plan_history_response import BackfillPlanHistoryResponse
+
+    d = dict(src_dict)
+    operation = d.pop("operation")
+
+    operation_id = d.pop("operationId")
+
+    status = OperationEnvelopeBackfillPlanHistoryResponseStatus(d.pop("status"))
+
+    at = d.pop("at")
+
+    def _parse_result(data: object) -> BackfillPlanHistoryResponse | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        result_type_0 = BackfillPlanHistoryResponse.from_dict(data)
+
+        return result_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(BackfillPlanHistoryResponse | None | Unset, data)
+
+    result = _parse_result(d.pop("result", UNSET))
+
+    def _parse_created_by(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    created_by = _parse_created_by(d.pop("createdBy", UNSET))
+
+    idempotent_replay = d.pop("idempotentReplay", UNSET)
+
+    operation_envelope_backfill_plan_history_response = cls(
+      operation=operation,
+      operation_id=operation_id,
+      status=status,
+      at=at,
+      result=result,
+      created_by=created_by,
+      idempotent_replay=idempotent_replay,
+    )
+
+    operation_envelope_backfill_plan_history_response.additional_properties = d
+    return operation_envelope_backfill_plan_history_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_backfill_plan_history_response_status.py
+++ b/robosystems_client/models/operation_envelope_backfill_plan_history_response_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class OperationEnvelopeBackfillPlanHistoryResponseStatus(str, Enum):
+  COMPLETED = "completed"
+  FAILED = "failed"
+  PENDING = "pending"
+
+  def __str__(self) -> str:
+    return str(self.value)

--- a/robosystems_client/models/update_forecast_arm.py
+++ b/robosystems_client/models/update_forecast_arm.py
@@ -25,11 +25,13 @@ class UpdateForecastArm:
           block_type (Literal['forecast']): Discriminator value selecting this arm.
           payload (UpdateForecastRequest): Update a forecast block in place.
 
-              Mutable: name, scenario_kind, horizon_months, base_period, levers.
-              ``levers`` is a **full replace** when provided (partial lever edits
-              would make the asserted set ambiguous). Updating does NOT recompute —
-              previously computed scenario months go stale until the next
-              ``compute-forecast`` run (the compute-metrics drift semantics).
+              Mutable: name, scenario_kind, horizon_months, base_period, levers,
+              line_assertions. ``levers`` and ``line_assertions`` are each a
+              **full replace** when provided (partial edits would make the asserted
+              set ambiguous); replacing one leaves the other as stored. Updating
+              does NOT recompute — previously computed scenario months go stale
+              until the next ``compute-forecast`` run (the compute-metrics drift
+              semantics).
   """
 
   block_type: Literal["forecast"]

--- a/robosystems_client/models/update_forecast_request.py
+++ b/robosystems_client/models/update_forecast_request.py
@@ -13,6 +13,7 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
   from ..models.lever_assertion_request import LeverAssertionRequest
+  from ..models.line_assertion_request import LineAssertionRequest
 
 
 T = TypeVar("T", bound="UpdateForecastRequest")
@@ -22,11 +23,13 @@ T = TypeVar("T", bound="UpdateForecastRequest")
 class UpdateForecastRequest:
   """Update a forecast block in place.
 
-  Mutable: name, scenario_kind, horizon_months, base_period, levers.
-  ``levers`` is a **full replace** when provided (partial lever edits
-  would make the asserted set ambiguous). Updating does NOT recompute —
-  previously computed scenario months go stale until the next
-  ``compute-forecast`` run (the compute-metrics drift semantics).
+  Mutable: name, scenario_kind, horizon_months, base_period, levers,
+  line_assertions. ``levers`` and ``line_assertions`` are each a
+  **full replace** when provided (partial edits would make the asserted
+  set ambiguous); replacing one leaves the other as stored. Updating
+  does NOT recompute — previously computed scenario months go stale
+  until the next ``compute-forecast`` run (the compute-metrics drift
+  semantics).
 
       Attributes:
           structure_id (str): Structure ID of the forecast block.
@@ -35,6 +38,8 @@ class UpdateForecastRequest:
           horizon_months (int | None | Unset):
           base_period (None | str | Unset):
           levers (list[LeverAssertionRequest] | None | Unset): Full replacement of the lever set when provided.
+          line_assertions (list[LineAssertionRequest] | None | Unset): Full replacement of the line-assertion set when
+              provided. Pass an empty list to clear every assertion.
   """
 
   structure_id: str
@@ -43,6 +48,7 @@ class UpdateForecastRequest:
   horizon_months: int | None | Unset = UNSET
   base_period: None | str | Unset = UNSET
   levers: list[LeverAssertionRequest] | None | Unset = UNSET
+  line_assertions: list[LineAssertionRequest] | None | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -86,6 +92,18 @@ class UpdateForecastRequest:
     else:
       levers = self.levers
 
+    line_assertions: list[dict[str, Any]] | None | Unset
+    if isinstance(self.line_assertions, Unset):
+      line_assertions = UNSET
+    elif isinstance(self.line_assertions, list):
+      line_assertions = []
+      for line_assertions_type_0_item_data in self.line_assertions:
+        line_assertions_type_0_item = line_assertions_type_0_item_data.to_dict()
+        line_assertions.append(line_assertions_type_0_item)
+
+    else:
+      line_assertions = self.line_assertions
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -103,12 +121,15 @@ class UpdateForecastRequest:
       field_dict["base_period"] = base_period
     if levers is not UNSET:
       field_dict["levers"] = levers
+    if line_assertions is not UNSET:
+      field_dict["line_assertions"] = line_assertions
 
     return field_dict
 
   @classmethod
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.lever_assertion_request import LeverAssertionRequest
+    from ..models.line_assertion_request import LineAssertionRequest
 
     d = dict(src_dict)
     structure_id = d.pop("structure_id")
@@ -181,6 +202,32 @@ class UpdateForecastRequest:
 
     levers = _parse_levers(d.pop("levers", UNSET))
 
+    def _parse_line_assertions(
+      data: object,
+    ) -> list[LineAssertionRequest] | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, list):
+          raise TypeError()
+        line_assertions_type_0 = []
+        _line_assertions_type_0 = data
+        for line_assertions_type_0_item_data in _line_assertions_type_0:
+          line_assertions_type_0_item = LineAssertionRequest.from_dict(
+            line_assertions_type_0_item_data
+          )
+
+          line_assertions_type_0.append(line_assertions_type_0_item)
+
+        return line_assertions_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(list[LineAssertionRequest] | None | Unset, data)
+
+    line_assertions = _parse_line_assertions(d.pop("line_assertions", UNSET))
+
     update_forecast_request = cls(
       structure_id=structure_id,
       name=name,
@@ -188,6 +235,7 @@ class UpdateForecastRequest:
       horizon_months=horizon_months,
       base_period=base_period,
       levers=levers,
+      line_assertions=line_assertions,
     )
 
     update_forecast_request.additional_properties = d


### PR DESCRIPTION
## Summary

Regenerates the SDK against backend `main` (post robosystems#932), picking up the forecast **line assertions** surface and catching up the `backfill-plan-history` operation that was deferred at the last regen.

## Changes

- `line_assertions` on `CreateForecastRequest`/`UpdateForecastRequest`: `LineAssertionRequest` (wire model — qname → `value`/`values_by_period`) and `LineAssertionLite` (the mechanics copy on `ForecastMechanics`).
- The `backfill_plan_history` API module (robosystems#927) + `BackfillPlanHistoryOperation`/`BackfillPlanHistoryResponse`/`BackfillPeriodOutcome` models and the operation envelope.
- All additive — no breaking changes.

## Testing

`just test-all` — ruff check, ruff format, basedpyright, 439 passed / 17 skipped: all green.
