### PR TITLE
feat(sdk): regen — graph /metrics + /usage rename, instance resources

### DIFF
--- a/robosystems_client/api/usage/get_graph_metrics.py
+++ b/robosystems_client/api/usage/get_graph_metrics.py
@@ -18,7 +18,7 @@ def _get_kwargs(
 
   _kwargs: dict[str, Any] = {
     "method": "get",
-    "url": "/v1/graphs/{graph_id}/analytics".format(
+    "url": "/v1/graphs/{graph_id}/metrics".format(
       graph_id=quote(str(graph_id), safe=""),
     ),
   }

--- a/robosystems_client/api/usage/get_graph_usage.py
+++ b/robosystems_client/api/usage/get_graph_usage.py
@@ -38,7 +38,7 @@ def _get_kwargs(
 
   _kwargs: dict[str, Any] = {
     "method": "get",
-    "url": "/v1/graphs/{graph_id}/analytics/usage".format(
+    "url": "/v1/graphs/{graph_id}/usage".format(
       graph_id=quote(str(graph_id), safe=""),
     ),
     "params": params,
@@ -117,7 +117,7 @@ def sync_detailed(
   include_performance: bool | Unset = False,
   include_events: bool | Unset = False,
 ) -> Response[ErrorResponse | GraphUsageResponse | HTTPValidationError]:
-  """Get Graph Usage Analytics
+  """Get Graph Usage
 
    Time ranges: 24h, 7d, 30d, current_month, last_month. Toggle storage, credits, performance, and
   events sections via query params.
@@ -166,7 +166,7 @@ def sync(
   include_performance: bool | Unset = False,
   include_events: bool | Unset = False,
 ) -> ErrorResponse | GraphUsageResponse | HTTPValidationError | None:
-  """Get Graph Usage Analytics
+  """Get Graph Usage
 
    Time ranges: 24h, 7d, 30d, current_month, last_month. Toggle storage, credits, performance, and
   events sections via query params.
@@ -210,7 +210,7 @@ async def asyncio_detailed(
   include_performance: bool | Unset = False,
   include_events: bool | Unset = False,
 ) -> Response[ErrorResponse | GraphUsageResponse | HTTPValidationError]:
-  """Get Graph Usage Analytics
+  """Get Graph Usage
 
    Time ranges: 24h, 7d, 30d, current_month, last_month. Toggle storage, credits, performance, and
   events sections via query params.
@@ -257,7 +257,7 @@ async def asyncio(
   include_performance: bool | Unset = False,
   include_events: bool | Unset = False,
 ) -> ErrorResponse | GraphUsageResponse | HTTPValidationError | None:
-  """Get Graph Usage Analytics
+  """Get Graph Usage
 
    Time ranges: 24h, 7d, 30d, current_month, last_month. Toggle storage, credits, performance, and
   events sections via query params.

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -299,6 +299,12 @@ from .line_assertion_request import LineAssertionRequest
 from .line_assertion_request_values_by_period_type_0 import (
   LineAssertionRequestValuesByPeriodType0,
 )
+from .line_growth_lite import LineGrowthLite
+from .line_growth_lite_values_by_period import LineGrowthLiteValuesByPeriod
+from .line_growth_request import LineGrowthRequest
+from .line_growth_request_values_by_period_type_0 import (
+  LineGrowthRequestValuesByPeriodType0,
+)
 from .line_item_metadata_predicate import LineItemMetadataPredicate
 from .link_entity_taxonomy_request import LinkEntityTaxonomyRequest
 from .link_entity_taxonomy_request_basis import LinkEntityTaxonomyRequestBasis
@@ -1043,6 +1049,10 @@ __all__ = (
   "LineAssertionLiteValuesByPeriod",
   "LineAssertionRequest",
   "LineAssertionRequestValuesByPeriodType0",
+  "LineGrowthLite",
+  "LineGrowthLiteValuesByPeriod",
+  "LineGrowthRequest",
+  "LineGrowthRequestValuesByPeriodType0",
   "LineItemMetadataPredicate",
   "LinkEntityTaxonomyRequest",
   "LinkEntityTaxonomyRequestBasis",

--- a/robosystems_client/models/backfill_plan_history_operation.py
+++ b/robosystems_client/models/backfill_plan_history_operation.py
@@ -22,12 +22,17 @@ class BackfillPlanHistoryOperation:
           cycle; keep chunks modest and loop on `remaining_periods`. Default: 12.
       allow_stale_sync (bool | Unset): Override the sync-currency gate on each reclose. Historical months predate the
           last sync in the normal case, so this is rarely needed. Default: False.
+      restamp (bool | Unset): Also re-derive months that ALREADY have canonical statement sets (default: skip them).
+          Use after an engine improvement changes what a stamp produces — each month reruns the full reopen → reclose
+          cycle and replaces its sets. A restamp run is not self-resuming (every month in range stays a candidate);
+          advance `start_period` between chunks. Default: False.
       note (None | str | Unset): Free-form note attached to each close audit event
   """
 
   start_period: None | str | Unset = UNSET
   max_periods: int | Unset = 12
   allow_stale_sync: bool | Unset = False
+  restamp: bool | Unset = False
   note: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -41,6 +46,8 @@ class BackfillPlanHistoryOperation:
     max_periods = self.max_periods
 
     allow_stale_sync = self.allow_stale_sync
+
+    restamp = self.restamp
 
     note: None | str | Unset
     if isinstance(self.note, Unset):
@@ -57,6 +64,8 @@ class BackfillPlanHistoryOperation:
       field_dict["max_periods"] = max_periods
     if allow_stale_sync is not UNSET:
       field_dict["allow_stale_sync"] = allow_stale_sync
+    if restamp is not UNSET:
+      field_dict["restamp"] = restamp
     if note is not UNSET:
       field_dict["note"] = note
 
@@ -79,6 +88,8 @@ class BackfillPlanHistoryOperation:
 
     allow_stale_sync = d.pop("allow_stale_sync", UNSET)
 
+    restamp = d.pop("restamp", UNSET)
+
     def _parse_note(data: object) -> None | str | Unset:
       if data is None:
         return data
@@ -92,6 +103,7 @@ class BackfillPlanHistoryOperation:
       start_period=start_period,
       max_periods=max_periods,
       allow_stale_sync=allow_stale_sync,
+      restamp=restamp,
       note=note,
     )
 

--- a/robosystems_client/models/create_forecast_request.py
+++ b/robosystems_client/models/create_forecast_request.py
@@ -14,6 +14,7 @@ from ..types import UNSET, Unset
 if TYPE_CHECKING:
   from ..models.lever_assertion_request import LeverAssertionRequest
   from ..models.line_assertion_request import LineAssertionRequest
+  from ..models.line_growth_request import LineGrowthRequest
 
 
 T = TypeVar("T", bound="CreateForecastRequest")
@@ -40,6 +41,9 @@ class CreateForecastRequest:
               time.
           line_assertions (list[LineAssertionRequest] | Unset): Direct statement-line assertions (manual overrides). Each
               names a calc-DAG leaf and wins over driver rules and carry-forward for the months it asserts.
+          line_growth (list[LineGrowthRequest] | Unset): Per-line growth trajectories. Each names an income-statement leaf
+              and grows it month-over-month at the asserted rate — the generic form of the revenue growth lever, for lines the
+              catalog doesn't drive (opex trajectories, cost-cut ramps).
           entity_id (None | str | Unset): Entity the scenario belongs to. Defaults to the graph's earliest-created entity
               (single-entity convention).
   """
@@ -52,6 +56,7 @@ class CreateForecastRequest:
   horizon_months: int | Unset = 12
   base_period: None | str | Unset = UNSET
   line_assertions: list[LineAssertionRequest] | Unset = UNSET
+  line_growth: list[LineGrowthRequest] | Unset = UNSET
   entity_id: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -82,6 +87,13 @@ class CreateForecastRequest:
         line_assertions_item = line_assertions_item_data.to_dict()
         line_assertions.append(line_assertions_item)
 
+    line_growth: list[dict[str, Any]] | Unset = UNSET
+    if not isinstance(self.line_growth, Unset):
+      line_growth = []
+      for line_growth_item_data in self.line_growth:
+        line_growth_item = line_growth_item_data.to_dict()
+        line_growth.append(line_growth_item)
+
     entity_id: None | str | Unset
     if isinstance(self.entity_id, Unset):
       entity_id = UNSET
@@ -104,6 +116,8 @@ class CreateForecastRequest:
       field_dict["base_period"] = base_period
     if line_assertions is not UNSET:
       field_dict["line_assertions"] = line_assertions
+    if line_growth is not UNSET:
+      field_dict["line_growth"] = line_growth
     if entity_id is not UNSET:
       field_dict["entity_id"] = entity_id
 
@@ -113,6 +127,7 @@ class CreateForecastRequest:
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.lever_assertion_request import LeverAssertionRequest
     from ..models.line_assertion_request import LineAssertionRequest
+    from ..models.line_growth_request import LineGrowthRequest
 
     d = dict(src_dict)
     name = d.pop("name")
@@ -151,6 +166,15 @@ class CreateForecastRequest:
 
         line_assertions.append(line_assertions_item)
 
+    _line_growth = d.pop("line_growth", UNSET)
+    line_growth: list[LineGrowthRequest] | Unset = UNSET
+    if _line_growth is not UNSET:
+      line_growth = []
+      for line_growth_item_data in _line_growth:
+        line_growth_item = LineGrowthRequest.from_dict(line_growth_item_data)
+
+        line_growth.append(line_growth_item)
+
     def _parse_entity_id(data: object) -> None | str | Unset:
       if data is None:
         return data
@@ -167,6 +191,7 @@ class CreateForecastRequest:
       horizon_months=horizon_months,
       base_period=base_period,
       line_assertions=line_assertions,
+      line_growth=line_growth,
       entity_id=entity_id,
     )
 

--- a/robosystems_client/models/database_health_response.py
+++ b/robosystems_client/models/database_health_response.py
@@ -24,7 +24,15 @@ class DatabaseHealthResponse:
       avg_query_time_ms (float): Average query execution time in milliseconds
       error_rate_24h (float): Error rate in last 24 hours (percentage)
       last_query_time (None | str | Unset): Timestamp of last query execution
-      memory_usage_mb (float | None | Unset): Memory usage in MB
+      memory_usage_mb (float | None | Unset): Instance memory in use, MB. Only populated for dedicated single-tenant
+          instances; null on shared repositories and packed tiers.
+      memory_usage_percent (float | None | Unset): Instance memory in use, percent. Expect high values during
+          materialization — the engine deliberately boosts to near the whole instance while rebuilding. Read
+          `resource_status` rather than this number alone. Dedicated instances only.
+      cpu_usage_percent (float | None | Unset): Instance CPU in use, percent. Dedicated single-tenant instances only.
+      resource_status (None | str | Unset): Interpreted instance load: 'idle' (headroom), 'busy' (working normally —
+          typical while materializing), 'constrained' (sustained pressure worth acting on). Null when resource metrics are
+          not exposed.
       storage_usage_mb (float | None | Unset): Storage usage in MB
       alerts (list[str] | Unset): Active alerts or warnings
       is_stale (bool | Unset): Whether the graph has staged changes not yet materialized Default: False.
@@ -43,6 +51,9 @@ class DatabaseHealthResponse:
   error_rate_24h: float
   last_query_time: None | str | Unset = UNSET
   memory_usage_mb: float | None | Unset = UNSET
+  memory_usage_percent: float | None | Unset = UNSET
+  cpu_usage_percent: float | None | Unset = UNSET
+  resource_status: None | str | Unset = UNSET
   storage_usage_mb: float | None | Unset = UNSET
   alerts: list[str] | Unset = UNSET
   is_stale: bool | Unset = False
@@ -78,6 +89,24 @@ class DatabaseHealthResponse:
       memory_usage_mb = UNSET
     else:
       memory_usage_mb = self.memory_usage_mb
+
+    memory_usage_percent: float | None | Unset
+    if isinstance(self.memory_usage_percent, Unset):
+      memory_usage_percent = UNSET
+    else:
+      memory_usage_percent = self.memory_usage_percent
+
+    cpu_usage_percent: float | None | Unset
+    if isinstance(self.cpu_usage_percent, Unset):
+      cpu_usage_percent = UNSET
+    else:
+      cpu_usage_percent = self.cpu_usage_percent
+
+    resource_status: None | str | Unset
+    if isinstance(self.resource_status, Unset):
+      resource_status = UNSET
+    else:
+      resource_status = self.resource_status
 
     storage_usage_mb: float | None | Unset
     if isinstance(self.storage_usage_mb, Unset):
@@ -132,6 +161,12 @@ class DatabaseHealthResponse:
       field_dict["last_query_time"] = last_query_time
     if memory_usage_mb is not UNSET:
       field_dict["memory_usage_mb"] = memory_usage_mb
+    if memory_usage_percent is not UNSET:
+      field_dict["memory_usage_percent"] = memory_usage_percent
+    if cpu_usage_percent is not UNSET:
+      field_dict["cpu_usage_percent"] = cpu_usage_percent
+    if resource_status is not UNSET:
+      field_dict["resource_status"] = resource_status
     if storage_usage_mb is not UNSET:
       field_dict["storage_usage_mb"] = storage_usage_mb
     if alerts is not UNSET:
@@ -183,6 +218,35 @@ class DatabaseHealthResponse:
       return cast(float | None | Unset, data)
 
     memory_usage_mb = _parse_memory_usage_mb(d.pop("memory_usage_mb", UNSET))
+
+    def _parse_memory_usage_percent(data: object) -> float | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(float | None | Unset, data)
+
+    memory_usage_percent = _parse_memory_usage_percent(
+      d.pop("memory_usage_percent", UNSET)
+    )
+
+    def _parse_cpu_usage_percent(data: object) -> float | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(float | None | Unset, data)
+
+    cpu_usage_percent = _parse_cpu_usage_percent(d.pop("cpu_usage_percent", UNSET))
+
+    def _parse_resource_status(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    resource_status = _parse_resource_status(d.pop("resource_status", UNSET))
 
     def _parse_storage_usage_mb(data: object) -> float | None | Unset:
       if data is None:
@@ -247,6 +311,9 @@ class DatabaseHealthResponse:
       error_rate_24h=error_rate_24h,
       last_query_time=last_query_time,
       memory_usage_mb=memory_usage_mb,
+      memory_usage_percent=memory_usage_percent,
+      cpu_usage_percent=cpu_usage_percent,
+      resource_status=resource_status,
       storage_usage_mb=storage_usage_mb,
       alerts=alerts,
       is_stale=is_stale,

--- a/robosystems_client/models/forecast_mechanics.py
+++ b/robosystems_client/models/forecast_mechanics.py
@@ -12,6 +12,7 @@ from ..types import UNSET, Unset
 if TYPE_CHECKING:
   from ..models.lever_assertion_lite import LeverAssertionLite
   from ..models.line_assertion_lite import LineAssertionLite
+  from ..models.line_growth_lite import LineGrowthLite
 
 
 T = TypeVar("T", bound="ForecastMechanics")
@@ -41,6 +42,8 @@ class ForecastMechanics:
               Default: ForecastMechanicsScenarioKind.FORECAST.
           line_assertions (list[LineAssertionLite] | Unset): Direct statement-line assertions (authoring order) — manual
               overrides that win over driver rules and carry-forward for the months they name.
+          line_growth (list[LineGrowthLite] | Unset): Per-line growth trajectories (authoring order) — each grows an
+              income-statement leaf month-over-month at the asserted rate, compounding from the base month.
           computed_months (int | Unset): Number of forward months with computed scenario FactSets. Runtime state filled at
               envelope-build time — 0 until the first compute-forecast run. Default: 0.
   """
@@ -53,6 +56,7 @@ class ForecastMechanics:
     ForecastMechanicsScenarioKind.FORECAST
   )
   line_assertions: list[LineAssertionLite] | Unset = UNSET
+  line_growth: list[LineGrowthLite] | Unset = UNSET
   computed_months: int | Unset = 0
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -79,6 +83,13 @@ class ForecastMechanics:
         line_assertions_item = line_assertions_item_data.to_dict()
         line_assertions.append(line_assertions_item)
 
+    line_growth: list[dict[str, Any]] | Unset = UNSET
+    if not isinstance(self.line_growth, Unset):
+      line_growth = []
+      for line_growth_item_data in self.line_growth:
+        line_growth_item = line_growth_item_data.to_dict()
+        line_growth.append(line_growth_item)
+
     computed_months = self.computed_months
 
     field_dict: dict[str, Any] = {}
@@ -96,6 +107,8 @@ class ForecastMechanics:
       field_dict["scenario_kind"] = scenario_kind
     if line_assertions is not UNSET:
       field_dict["line_assertions"] = line_assertions
+    if line_growth is not UNSET:
+      field_dict["line_growth"] = line_growth
     if computed_months is not UNSET:
       field_dict["computed_months"] = computed_months
 
@@ -105,6 +118,7 @@ class ForecastMechanics:
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.lever_assertion_lite import LeverAssertionLite
     from ..models.line_assertion_lite import LineAssertionLite
+    from ..models.line_growth_lite import LineGrowthLite
 
     d = dict(src_dict)
     horizon_months = d.pop("horizon_months")
@@ -138,6 +152,15 @@ class ForecastMechanics:
 
         line_assertions.append(line_assertions_item)
 
+    _line_growth = d.pop("line_growth", UNSET)
+    line_growth: list[LineGrowthLite] | Unset = UNSET
+    if _line_growth is not UNSET:
+      line_growth = []
+      for line_growth_item_data in _line_growth:
+        line_growth_item = LineGrowthLite.from_dict(line_growth_item_data)
+
+        line_growth.append(line_growth_item)
+
     computed_months = d.pop("computed_months", UNSET)
 
     forecast_mechanics = cls(
@@ -147,6 +170,7 @@ class ForecastMechanics:
       kind=kind,
       scenario_kind=scenario_kind,
       line_assertions=line_assertions,
+      line_growth=line_growth,
       computed_months=computed_months,
     )
 

--- a/robosystems_client/models/line_growth_lite.py
+++ b/robosystems_client/models/line_growth_lite.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.line_growth_lite_values_by_period import LineGrowthLiteValuesByPeriod
+
+
+T = TypeVar("T", bound="LineGrowthLite")
+
+
+@_attrs_define
+class LineGrowthLite:
+  """One statement line's persisted growth trajectory inside
+  ``ForecastMechanics``.
+
+  The generic per-line form of the revenue growth lever: grows an
+  income-statement leaf month-over-month at the asserted rate
+  (``line[t] = line[t-1] * (1 + rate[t])``), compounding from the base
+  month's value. Months without a rate keep the engine's carry-forward.
+  Duration leaves only; disjoint from ``line_assertions`` and from any
+  active catalog rule's target (one owner per line).
+
+  Persistence deviates from levers/assertions deliberately: rates are
+  NOT duplicated as facts in the scenario FactSet — a growth rate on a
+  monetary statement element would be a unit-lying fact. This mechanics
+  copy is the single authored store; ``compute-forecast`` binds rates
+  from here.
+
+      Attributes:
+          qname (str): Grown statement-leaf qname.
+          element_id (str): Resolved tenant element id.
+          values_by_period (LineGrowthLiteValuesByPeriod): Expanded per-month growth rates keyed by ``YYYY-MM``.
+          item_type (str | Unset): Always 'percent' — the grid row renders rates, not values. Default: 'percent'.
+  """
+
+  qname: str
+  element_id: str
+  values_by_period: LineGrowthLiteValuesByPeriod
+  item_type: str | Unset = "percent"
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    qname = self.qname
+
+    element_id = self.element_id
+
+    values_by_period = self.values_by_period.to_dict()
+
+    item_type = self.item_type
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "qname": qname,
+        "element_id": element_id,
+        "values_by_period": values_by_period,
+      }
+    )
+    if item_type is not UNSET:
+      field_dict["item_type"] = item_type
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.line_growth_lite_values_by_period import LineGrowthLiteValuesByPeriod
+
+    d = dict(src_dict)
+    qname = d.pop("qname")
+
+    element_id = d.pop("element_id")
+
+    values_by_period = LineGrowthLiteValuesByPeriod.from_dict(d.pop("values_by_period"))
+
+    item_type = d.pop("item_type", UNSET)
+
+    line_growth_lite = cls(
+      qname=qname,
+      element_id=element_id,
+      values_by_period=values_by_period,
+      item_type=item_type,
+    )
+
+    line_growth_lite.additional_properties = d
+    return line_growth_lite
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/line_growth_lite_values_by_period.py
+++ b/robosystems_client/models/line_growth_lite_values_by_period.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="LineGrowthLiteValuesByPeriod")
+
+
+@_attrs_define
+class LineGrowthLiteValuesByPeriod:
+  """Expanded per-month growth rates keyed by ``YYYY-MM``."""
+
+  additional_properties: dict[str, float] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    line_growth_lite_values_by_period = cls()
+
+    line_growth_lite_values_by_period.additional_properties = d
+    return line_growth_lite_values_by_period
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> float:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: float) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/line_growth_request.py
+++ b/robosystems_client/models/line_growth_request.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.line_growth_request_values_by_period_type_0 import (
+    LineGrowthRequestValuesByPeriodType0,
+  )
+
+
+T = TypeVar("T", bound="LineGrowthRequest")
+
+
+@_attrs_define
+class LineGrowthRequest:
+  """One statement line's asserted growth trajectory for the scenario.
+
+  The generic per-line sibling of ``rs-driver:RevenueGrowthRate``: where
+  the catalog lever grows *revenue* through its seeded rule, a line
+  growth entry grows **any income-statement leaf** at a month-over-month
+  rate — ``value`` -0.05 cuts the line 5% per month, compounding from
+  the base month's value. This is what expense trajectories ("opex +2%/mo
+  with inflation", "cut costs 5%/mo starting October") use; without it
+  every unmodeled line just carries flat.
+
+  Semantics per month: ``line[t] = line[t-1] * (1 + rate[t])``. Months
+  the entry doesn't name keep the engine's carry-forward (grow-then-hold
+  ramps fall out of ``values_by_period`` naturally). **Duration leaves
+  only**: balance-sheet lines roll from the IS and the working-capital
+  levers — grow the driving IS line instead. A line already driven by an
+  active catalog rule (e.g. Revenues with ``RevenueGrowthRate`` set) or
+  named by a ``line_assertions`` entry is rejected — one owner per line.
+
+      Attributes:
+          qname (str): QName of the income-statement leaf to grow (e.g. ``rs-gaap:ResearchAndDevelopmentExpense``). Must
+              be a calc-DAG duration leaf.
+          value (float | None | Unset): Uniform month-over-month growth rate for every month of the horizon (decimal: 0.02
+              = +2%/mo, -0.05 = -5%/mo).
+          values_by_period (LineGrowthRequestValuesByPeriodType0 | None | Unset): Per-month rate overrides keyed by
+              ``YYYY-MM``. Wins over ``value`` for the months it names; months named by neither carry the line's prior value
+              (rate 0).
+  """
+
+  qname: str
+  value: float | None | Unset = UNSET
+  values_by_period: LineGrowthRequestValuesByPeriodType0 | None | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.line_growth_request_values_by_period_type_0 import (
+      LineGrowthRequestValuesByPeriodType0,
+    )
+
+    qname = self.qname
+
+    value: float | None | Unset
+    if isinstance(self.value, Unset):
+      value = UNSET
+    else:
+      value = self.value
+
+    values_by_period: dict[str, Any] | None | Unset
+    if isinstance(self.values_by_period, Unset):
+      values_by_period = UNSET
+    elif isinstance(self.values_by_period, LineGrowthRequestValuesByPeriodType0):
+      values_by_period = self.values_by_period.to_dict()
+    else:
+      values_by_period = self.values_by_period
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "qname": qname,
+      }
+    )
+    if value is not UNSET:
+      field_dict["value"] = value
+    if values_by_period is not UNSET:
+      field_dict["values_by_period"] = values_by_period
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.line_growth_request_values_by_period_type_0 import (
+      LineGrowthRequestValuesByPeriodType0,
+    )
+
+    d = dict(src_dict)
+    qname = d.pop("qname")
+
+    def _parse_value(data: object) -> float | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(float | None | Unset, data)
+
+    value = _parse_value(d.pop("value", UNSET))
+
+    def _parse_values_by_period(
+      data: object,
+    ) -> LineGrowthRequestValuesByPeriodType0 | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        values_by_period_type_0 = LineGrowthRequestValuesByPeriodType0.from_dict(data)
+
+        return values_by_period_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(LineGrowthRequestValuesByPeriodType0 | None | Unset, data)
+
+    values_by_period = _parse_values_by_period(d.pop("values_by_period", UNSET))
+
+    line_growth_request = cls(
+      qname=qname,
+      value=value,
+      values_by_period=values_by_period,
+    )
+
+    line_growth_request.additional_properties = d
+    return line_growth_request
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/line_growth_request_values_by_period_type_0.py
+++ b/robosystems_client/models/line_growth_request_values_by_period_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="LineGrowthRequestValuesByPeriodType0")
+
+
+@_attrs_define
+class LineGrowthRequestValuesByPeriodType0:
+  """ """
+
+  additional_properties: dict[str, float] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    line_growth_request_values_by_period_type_0 = cls()
+
+    line_growth_request_values_by_period_type_0.additional_properties = d
+    return line_growth_request_values_by_period_type_0
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> float:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: float) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/update_forecast_request.py
+++ b/robosystems_client/models/update_forecast_request.py
@@ -14,6 +14,7 @@ from ..types import UNSET, Unset
 if TYPE_CHECKING:
   from ..models.lever_assertion_request import LeverAssertionRequest
   from ..models.line_assertion_request import LineAssertionRequest
+  from ..models.line_growth_request import LineGrowthRequest
 
 
 T = TypeVar("T", bound="UpdateForecastRequest")
@@ -40,6 +41,8 @@ class UpdateForecastRequest:
           levers (list[LeverAssertionRequest] | None | Unset): Full replacement of the lever set when provided.
           line_assertions (list[LineAssertionRequest] | None | Unset): Full replacement of the line-assertion set when
               provided. Pass an empty list to clear every assertion.
+          line_growth (list[LineGrowthRequest] | None | Unset): Full replacement of the line-growth set when provided.
+              Pass an empty list to clear every growth entry.
   """
 
   structure_id: str
@@ -49,6 +52,7 @@ class UpdateForecastRequest:
   base_period: None | str | Unset = UNSET
   levers: list[LeverAssertionRequest] | None | Unset = UNSET
   line_assertions: list[LineAssertionRequest] | None | Unset = UNSET
+  line_growth: list[LineGrowthRequest] | None | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -104,6 +108,18 @@ class UpdateForecastRequest:
     else:
       line_assertions = self.line_assertions
 
+    line_growth: list[dict[str, Any]] | None | Unset
+    if isinstance(self.line_growth, Unset):
+      line_growth = UNSET
+    elif isinstance(self.line_growth, list):
+      line_growth = []
+      for line_growth_type_0_item_data in self.line_growth:
+        line_growth_type_0_item = line_growth_type_0_item_data.to_dict()
+        line_growth.append(line_growth_type_0_item)
+
+    else:
+      line_growth = self.line_growth
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -123,6 +139,8 @@ class UpdateForecastRequest:
       field_dict["levers"] = levers
     if line_assertions is not UNSET:
       field_dict["line_assertions"] = line_assertions
+    if line_growth is not UNSET:
+      field_dict["line_growth"] = line_growth
 
     return field_dict
 
@@ -130,6 +148,7 @@ class UpdateForecastRequest:
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.lever_assertion_request import LeverAssertionRequest
     from ..models.line_assertion_request import LineAssertionRequest
+    from ..models.line_growth_request import LineGrowthRequest
 
     d = dict(src_dict)
     structure_id = d.pop("structure_id")
@@ -228,6 +247,30 @@ class UpdateForecastRequest:
 
     line_assertions = _parse_line_assertions(d.pop("line_assertions", UNSET))
 
+    def _parse_line_growth(data: object) -> list[LineGrowthRequest] | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, list):
+          raise TypeError()
+        line_growth_type_0 = []
+        _line_growth_type_0 = data
+        for line_growth_type_0_item_data in _line_growth_type_0:
+          line_growth_type_0_item = LineGrowthRequest.from_dict(
+            line_growth_type_0_item_data
+          )
+
+          line_growth_type_0.append(line_growth_type_0_item)
+
+        return line_growth_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(list[LineGrowthRequest] | None | Unset, data)
+
+    line_growth = _parse_line_growth(d.pop("line_growth", UNSET))
+
     update_forecast_request = cls(
       structure_id=structure_id,
       name=name,
@@ -236,6 +279,7 @@ class UpdateForecastRequest:
       base_period=base_period,
       levers=levers,
       line_assertions=line_assertions,
+      line_growth=line_growth,
     )
 
     update_forecast_request.additional_properties = d


### PR DESCRIPTION
## Summary

Regenerates the SDK against the backend `refactor/analytics-to-usage` branch, picking up the graph endpoint rename and the new instance-resource fields on the health response.

> [!IMPORTANT]
> **Merge after the backend PR.** These routes do not exist on `main` yet — merging this first would ship a client pointing at 404s.

## Changes

**Endpoint rename** (backend P0)

| Before | After |
| --- | --- |
| `/v1/graphs/{graph_id}/analytics` | `/v1/graphs/{graph_id}/metrics` |
| `/v1/graphs/{graph_id}/analytics/usage` | `/v1/graphs/{graph_id}/usage` |

- `get_graph_metrics` keeps its name — only its URL moved, so callers are unaffected.
- `get_graph_usage_analytics` → `get_graph_usage` (git records it as a 98% rename). It had no consumers.

**Instance resources on `DatabaseHealthResponse`**

- New: `cpu_usage_percent`, `memory_usage_percent`, `resource_status` (`idle` / `busy` / `constrained`).
- `memory_usage_mb` is now actually populated — it had been declared and hardcoded `None` server-side.
- All four are returned **only for dedicated single-tenant instances** and are `null` on shared repositories, so treat them as optional at every call site.

**Upstream catch-up** (already merged server-side, not part of this initiative)

- Line growth: `LineGrowthLite`, `LineGrowthLiteValuesByPeriod`, `LineGrowthRequest`, `LineGrowthRequestValuesByPeriodType0`
- `ForecastMechanics`, `CreateForecastRequest`, `UpdateForecastRequest`, `BackfillPlanHistoryOperation`

## Testing

`just test-all` — ruff check, ruff format, basedpyright 0 errors, 439 passed / 17 skipped: all green.

Pure regen output — no hand edits. Version bump / release handled separately by the publish flow.