### PR TITLE
feat(sdk): regen — measured graph storage replaces the size estimate

### DIFF
--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -244,12 +244,12 @@ from .graph_info import GraphInfo
 from .graph_limits_response import GraphLimitsResponse
 from .graph_metadata import GraphMetadata
 from .graph_metrics_response import GraphMetricsResponse
-from .graph_metrics_response_estimated_size import GraphMetricsResponseEstimatedSize
 from .graph_metrics_response_health_status import GraphMetricsResponseHealthStatus
 from .graph_metrics_response_node_counts import GraphMetricsResponseNodeCounts
 from .graph_metrics_response_relationship_counts import (
   GraphMetricsResponseRelationshipCounts,
 )
+from .graph_metrics_response_storage import GraphMetricsResponseStorage
 from .graph_subscription_response import GraphSubscriptionResponse
 from .graph_subscription_tier import GraphSubscriptionTier
 from .graph_subscriptions import GraphSubscriptions
@@ -667,6 +667,7 @@ from .sso_exchange_request import SSOExchangeRequest
 from .sso_exchange_response import SSOExchangeResponse
 from .sso_token_response import SSOTokenResponse
 from .statement_mechanics import StatementMechanics
+from .storage_item import StorageItem
 from .storage_limits import StorageLimits
 from .storage_summary import StorageSummary
 from .structure_summary import StructureSummary
@@ -1004,10 +1005,10 @@ __all__ = (
   "GraphLimitsResponse",
   "GraphMetadata",
   "GraphMetricsResponse",
-  "GraphMetricsResponseEstimatedSize",
   "GraphMetricsResponseHealthStatus",
   "GraphMetricsResponseNodeCounts",
   "GraphMetricsResponseRelationshipCounts",
+  "GraphMetricsResponseStorage",
   "GraphSubscriptionResponse",
   "GraphSubscriptions",
   "GraphSubscriptionTier",
@@ -1275,6 +1276,7 @@ __all__ = (
   "SSOExchangeResponse",
   "SSOTokenResponse",
   "StatementMechanics",
+  "StorageItem",
   "StorageLimits",
   "StorageSummary",
   "StructureSummary",

--- a/robosystems_client/models/graph_metrics_response.py
+++ b/robosystems_client/models/graph_metrics_response.py
@@ -9,9 +9,6 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-  from ..models.graph_metrics_response_estimated_size import (
-    GraphMetricsResponseEstimatedSize,
-  )
   from ..models.graph_metrics_response_health_status import (
     GraphMetricsResponseHealthStatus,
   )
@@ -19,6 +16,7 @@ if TYPE_CHECKING:
   from ..models.graph_metrics_response_relationship_counts import (
     GraphMetricsResponseRelationshipCounts,
   )
+  from ..models.graph_metrics_response_storage import GraphMetricsResponseStorage
 
 
 T = TypeVar("T", bound="GraphMetricsResponse")
@@ -35,7 +33,9 @@ class GraphMetricsResponse:
       total_relationships (int): Total number of relationships
       node_counts (GraphMetricsResponseNodeCounts): Node counts by label
       relationship_counts (GraphMetricsResponseRelationshipCounts): Relationship counts by type
-      estimated_size (GraphMetricsResponseEstimatedSize): Database size estimates
+      storage (GraphMetricsResponseStorage): Measured on-disk storage: total_bytes/kb/mb/gb plus itemized `items`
+          (graph, memory, subgraph, vectors, staging). Carries `error` instead if the instance could not be reached — the
+          fields are absent rather than estimated.
       health_status (GraphMetricsResponseHealthStatus): Database health information
       graph_name (None | str | Unset): Display name for the graph
       user_role (None | str | Unset): User's role in this graph
@@ -47,7 +47,7 @@ class GraphMetricsResponse:
   total_relationships: int
   node_counts: GraphMetricsResponseNodeCounts
   relationship_counts: GraphMetricsResponseRelationshipCounts
-  estimated_size: GraphMetricsResponseEstimatedSize
+  storage: GraphMetricsResponseStorage
   health_status: GraphMetricsResponseHealthStatus
   graph_name: None | str | Unset = UNSET
   user_role: None | str | Unset = UNSET
@@ -66,7 +66,7 @@ class GraphMetricsResponse:
 
     relationship_counts = self.relationship_counts.to_dict()
 
-    estimated_size = self.estimated_size.to_dict()
+    storage = self.storage.to_dict()
 
     health_status = self.health_status.to_dict()
 
@@ -92,7 +92,7 @@ class GraphMetricsResponse:
         "total_relationships": total_relationships,
         "node_counts": node_counts,
         "relationship_counts": relationship_counts,
-        "estimated_size": estimated_size,
+        "storage": storage,
         "health_status": health_status,
       }
     )
@@ -105,9 +105,6 @@ class GraphMetricsResponse:
 
   @classmethod
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-    from ..models.graph_metrics_response_estimated_size import (
-      GraphMetricsResponseEstimatedSize,
-    )
     from ..models.graph_metrics_response_health_status import (
       GraphMetricsResponseHealthStatus,
     )
@@ -117,6 +114,7 @@ class GraphMetricsResponse:
     from ..models.graph_metrics_response_relationship_counts import (
       GraphMetricsResponseRelationshipCounts,
     )
+    from ..models.graph_metrics_response_storage import GraphMetricsResponseStorage
 
     d = dict(src_dict)
     graph_id = d.pop("graph_id")
@@ -133,9 +131,7 @@ class GraphMetricsResponse:
       d.pop("relationship_counts")
     )
 
-    estimated_size = GraphMetricsResponseEstimatedSize.from_dict(
-      d.pop("estimated_size")
-    )
+    storage = GraphMetricsResponseStorage.from_dict(d.pop("storage"))
 
     health_status = GraphMetricsResponseHealthStatus.from_dict(d.pop("health_status"))
 
@@ -164,7 +160,7 @@ class GraphMetricsResponse:
       total_relationships=total_relationships,
       node_counts=node_counts,
       relationship_counts=relationship_counts,
-      estimated_size=estimated_size,
+      storage=storage,
       health_status=health_status,
       graph_name=graph_name,
       user_role=user_role,

--- a/robosystems_client/models/graph_metrics_response_storage.py
+++ b/robosystems_client/models/graph_metrics_response_storage.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="GraphMetricsResponseStorage")
+
+
+@_attrs_define
+class GraphMetricsResponseStorage:
+  """Measured on-disk storage: total_bytes/kb/mb/gb plus itemized `items` (graph, memory, subgraph, vectors, staging).
+  Carries `error` instead if the instance could not be reached — the fields are absent rather than estimated.
+
+  """
+
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    graph_metrics_response_storage = cls()
+
+    graph_metrics_response_storage.additional_properties = d
+    return graph_metrics_response_storage
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/instance_usage.py
+++ b/robosystems_client/models/instance_usage.py
@@ -10,6 +10,7 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
   from ..models.database_storage_entry import DatabaseStorageEntry
+  from ..models.storage_item import StorageItem
 
 
 T = TypeVar("T", bound="InstanceUsage")
@@ -29,6 +30,8 @@ class InstanceUsage:
           total_storage_gb (float | None | Unset): Total storage used across all databases in GB
           usage_percentage (float | None | Unset): Storage usage as percentage of limit (e.g. 105.2)
           databases (list[DatabaseStorageEntry] | Unset): Per-database storage breakdown
+          items (list[StorageItem] | Unset): Itemized storage by type — graph, memory, subgraph, vectors, staging. Sums to
+              total_storage_gb.
   """
 
   limit_gb: float
@@ -37,6 +40,7 @@ class InstanceUsage:
   total_storage_gb: float | None | Unset = UNSET
   usage_percentage: float | None | Unset = UNSET
   databases: list[DatabaseStorageEntry] | Unset = UNSET
+  items: list[StorageItem] | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -69,6 +73,13 @@ class InstanceUsage:
         databases_item = databases_item_data.to_dict()
         databases.append(databases_item)
 
+    items: list[dict[str, Any]] | Unset = UNSET
+    if not isinstance(self.items, Unset):
+      items = []
+      for items_item_data in self.items:
+        items_item = items_item_data.to_dict()
+        items.append(items_item)
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -85,12 +96,15 @@ class InstanceUsage:
       field_dict["usage_percentage"] = usage_percentage
     if databases is not UNSET:
       field_dict["databases"] = databases
+    if items is not UNSET:
+      field_dict["items"] = items
 
     return field_dict
 
   @classmethod
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     from ..models.database_storage_entry import DatabaseStorageEntry
+    from ..models.storage_item import StorageItem
 
     d = dict(src_dict)
     limit_gb = d.pop("limit_gb")
@@ -133,6 +147,15 @@ class InstanceUsage:
 
         databases.append(databases_item)
 
+    _items = d.pop("items", UNSET)
+    items: list[StorageItem] | Unset = UNSET
+    if _items is not UNSET:
+      items = []
+      for items_item_data in _items:
+        items_item = StorageItem.from_dict(items_item_data)
+
+        items.append(items_item)
+
     instance_usage = cls(
       limit_gb=limit_gb,
       status=status,
@@ -140,6 +163,7 @@ class InstanceUsage:
       total_storage_gb=total_storage_gb,
       usage_percentage=usage_percentage,
       databases=databases,
+      items=items,
     )
 
     instance_usage.additional_properties = d

--- a/robosystems_client/models/storage_item.py
+++ b/robosystems_client/models/storage_item.py
@@ -6,29 +6,60 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="GraphMetricsResponseEstimatedSize")
+T = TypeVar("T", bound="StorageItem")
 
 
 @_attrs_define
-class GraphMetricsResponseEstimatedSize:
-  """Database size estimates"""
+class StorageItem:
+  """One itemized piece of a graph's on-disk footprint.
 
+  Attributes:
+      type_ (str): One of: graph, memory, subgraph, vectors, staging
+      id (str): Database or index identifier
+      bytes_ (int): Size in bytes
+  """
+
+  type_: str
+  id: str
+  bytes_: int
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
+    type_ = self.type_
+
+    id = self.id
+
+    bytes_ = self.bytes_
 
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "type": type_,
+        "id": id,
+        "bytes": bytes_,
+      }
+    )
 
     return field_dict
 
   @classmethod
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
     d = dict(src_dict)
-    graph_metrics_response_estimated_size = cls()
+    type_ = d.pop("type")
 
-    graph_metrics_response_estimated_size.additional_properties = d
-    return graph_metrics_response_estimated_size
+    id = d.pop("id")
+
+    bytes_ = d.pop("bytes")
+
+    storage_item = cls(
+      type_=type_,
+      id=id,
+      bytes_=bytes_,
+    )
+
+    storage_item.additional_properties = d
+    return storage_item
 
   @property
   def additional_keys(self) -> list[str]:


### PR DESCRIPTION
## Summary

Regenerates against robosystems#938, which replaces a `node_count * 100 bytes` storage guess with the measured on-disk total.

> [!WARNING]
> **Breaking for `get_graph_metrics` callers, and it fails loudly.** `estimated_size` was a **required** field parsed with `d.pop("estimated_size")`, so **0.5.8 raises `KeyError` against a server that has deployed #938**. Callers of `get_graph_metrics` must move to this release. Nothing else in the SDK is affected.

> [!IMPORTANT]
> **Merge and publish alongside the robosystems#938 deploy.** The goal is to keep the window short where prod returns `storage` but the newest published client demands `estimated_size`.

## Changes

**`GraphMetricsResponse.estimated_size` → `storage`**

| Before | After |
| --- | --- |
| `GraphMetricsResponseEstimatedSize` | `GraphMetricsResponseStorage` |
| `estimated_bytes` / `estimated_kb` / `estimated_mb`, `method`, `note` | `total_bytes` / `total_kb` / `total_mb` / `total_gb`, `items` |

The rename is not cosmetic: the server stopped estimating, so a field called `estimated_size` would have kept implying something that no longer happens. The value now spans the graph, its memory database, subgraphs, vector indexes and staging file.

An unreachable instance returns `{"error": ...}` with no total, rather than a fallback estimate.

**Upstream catch-up** — robosystems#937 storage work that landed *after* the 0.5.8 regen:

- `InstanceUsage` gains `items`
- New `StorageItem` model — per-type breakdown across graph, memory, subgraph, vectors, staging

## Testing

`just test-all` — ruff check, ruff format, basedpyright 0 errors, 439 passed / 17 skipped: all green.

Pure regen output — no hand edits. Version bump / release handled separately by the publish flow.