### PR TITLE
SDK regen — graph tier storage limit, reopen-period semantics

### DIFF
--- a/robosystems_client/api/extensions_robo_ledger/reopen_period.py
+++ b/robosystems_client/api/extensions_robo_ledger/reopen_period.py
@@ -113,9 +113,11 @@ def sync_detailed(
 ) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   """Reopen Fiscal Period
 
-   Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
-  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+   Reopen a closed period for adjustment. Reopening the current `closed_through` decrements it by one;
+  reopening an earlier period is a prior-period adjustment and leaves `closed_through` unchanged — re-
+  closing it restores the period without advancing the pointer. Either way the period's entries become
+  writable again. Retracts the month's canonical statement FactSets (a reopened month is no longer a
+  closed assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
   sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
   filings).
 
@@ -125,7 +127,7 @@ def sync_detailed(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ReopenPeriodOperation): Reopen the most recently closed fiscal period.
+      body (ReopenPeriodOperation): Reopen a closed fiscal period.
 
   Raises:
       errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -157,9 +159,11 @@ def sync(
 ) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   """Reopen Fiscal Period
 
-   Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
-  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+   Reopen a closed period for adjustment. Reopening the current `closed_through` decrements it by one;
+  reopening an earlier period is a prior-period adjustment and leaves `closed_through` unchanged — re-
+  closing it restores the period without advancing the pointer. Either way the period's entries become
+  writable again. Retracts the month's canonical statement FactSets (a reopened month is no longer a
+  closed assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
   sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
   filings).
 
@@ -169,7 +173,7 @@ def sync(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ReopenPeriodOperation): Reopen the most recently closed fiscal period.
+      body (ReopenPeriodOperation): Reopen a closed fiscal period.
 
   Raises:
       errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -196,9 +200,11 @@ async def asyncio_detailed(
 ) -> Response[ErrorResponse | OperationEnvelopeFiscalCalendarResponse]:
   """Reopen Fiscal Period
 
-   Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
-  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+   Reopen a closed period for adjustment. Reopening the current `closed_through` decrements it by one;
+  reopening an earlier period is a prior-period adjustment and leaves `closed_through` unchanged — re-
+  closing it restores the period without advancing the pointer. Either way the period's entries become
+  writable again. Retracts the month's canonical statement FactSets (a reopened month is no longer a
+  closed assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
   sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
   filings).
 
@@ -208,7 +214,7 @@ async def asyncio_detailed(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ReopenPeriodOperation): Reopen the most recently closed fiscal period.
+      body (ReopenPeriodOperation): Reopen a closed fiscal period.
 
   Raises:
       errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -238,9 +244,11 @@ async def asyncio(
 ) -> ErrorResponse | OperationEnvelopeFiscalCalendarResponse | None:
   """Reopen Fiscal Period
 
-   Decrement `closed_through` by one. Only the most recently closed period can be reopened (no reach-
-  back). Retracts the month's canonical statement FactSets (a reopened month is no longer a closed
-  assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
+   Reopen a closed period for adjustment. Reopening the current `closed_through` decrements it by one;
+  reopening an earlier period is a prior-period adjustment and leaves `closed_through` unchanged — re-
+  closing it restores the period without advancing the pointer. Either way the period's entries become
+  writable again. Retracts the month's canonical statement FactSets (a reopened month is no longer a
+  closed assertion; re-closing restamps them). The required `reason` is captured in the audit log. Use
   sparingly — reopen invalidates downstream artifacts that trusted the closed state (reports, shared
   filings).
 
@@ -250,7 +258,7 @@ async def asyncio(
   Args:
       graph_id (str):
       idempotency_key (None | str | Unset):
-      body (ReopenPeriodOperation): Reopen the most recently closed fiscal period.
+      body (ReopenPeriodOperation): Reopen a closed fiscal period.
 
   Raises:
       errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/robosystems_client/models/graph_subscription_tier.py
+++ b/robosystems_client/models/graph_subscription_tier.py
@@ -32,6 +32,7 @@ class GraphSubscriptionTier:
           backend (str): Database backend identifier
           max_subgraphs (int | Unset): Maximum subgraphs supported Default: 0.
           instance_type (None | str | Unset): Instance type
+          instance_storage_limit_gb (float | Unset): Soft storage cap for the instance in GB Default: 0.0.
   """
 
   name: str
@@ -47,6 +48,7 @@ class GraphSubscriptionTier:
   backend: str
   max_subgraphs: int | Unset = 0
   instance_type: None | str | Unset = UNSET
+  instance_storage_limit_gb: float | Unset = 0.0
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -80,6 +82,8 @@ class GraphSubscriptionTier:
     else:
       instance_type = self.instance_type
 
+    instance_storage_limit_gb = self.instance_storage_limit_gb
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -101,6 +105,8 @@ class GraphSubscriptionTier:
       field_dict["max_subgraphs"] = max_subgraphs
     if instance_type is not UNSET:
       field_dict["instance_type"] = instance_type
+    if instance_storage_limit_gb is not UNSET:
+      field_dict["instance_storage_limit_gb"] = instance_storage_limit_gb
 
     return field_dict
 
@@ -140,6 +146,8 @@ class GraphSubscriptionTier:
 
     instance_type = _parse_instance_type(d.pop("instance_type", UNSET))
 
+    instance_storage_limit_gb = d.pop("instance_storage_limit_gb", UNSET)
+
     graph_subscription_tier = cls(
       name=name,
       display_name=display_name,
@@ -154,6 +162,7 @@ class GraphSubscriptionTier:
       backend=backend,
       max_subgraphs=max_subgraphs,
       instance_type=instance_type,
+      instance_storage_limit_gb=instance_storage_limit_gb,
     )
 
     graph_subscription_tier.additional_properties = d

--- a/robosystems_client/models/reopen_period_operation.py
+++ b/robosystems_client/models/reopen_period_operation.py
@@ -13,12 +13,13 @@ T = TypeVar("T", bound="ReopenPeriodOperation")
 
 @_attrs_define
 class ReopenPeriodOperation:
-  """Reopen the most recently closed fiscal period.
+  """Reopen a closed fiscal period.
 
   Attributes:
       reason (str): Required reason for the reopen (captured in audit log)
-      period (str): Period to reopen, in YYYY-MM. Must equal current `closed_through` — only the most recent close can
-          be undone.
+      period (str): Period to reopen, in YYYY-MM. Any closed period may be reopened. Reopening the current
+          `closed_through` retreats it by one month; reopening an earlier period leaves `closed_through` where it is (a
+          prior-period adjustment), and its re-close restores the period without moving the pointer.
       note (None | str | Unset): Additional free-form note
   """
 


### PR DESCRIPTION
Regenerated against the live spec now that robosystems **v1.6.14** is deployed. Two backend deltas since the last regen, matching robosystems-typescript-client#160.

## `GraphSubscriptionTier.instance_storage_limit_gb`

```python
instance_storage_limit_gb: float | Unset = 0.0
```

The offerings router had been computing this value since the field was introduced, but it was never declared on the response model — so Pydantic silently dropped it for **every** tier, Standard included. Fixed in robosystems#945; this regen is what makes it reachable from the SDK.

## `reopen-period`

Now models prior-period adjustment: reopening an earlier period leaves `closed_through` unchanged rather than decrementing it, and re-closing restores the period without advancing the pointer. Both the operation body and its description change shape.

## Testing

`just test-all` — 439 passed, 17 skipped; ruff check, ruff format, and basedpyright all clean (0 errors, 0 warnings).