### PR TITLE
chore(sdk): regen — tier claim descriptions align with what runs

### DIFF
--- a/robosystems_client/models/backup_create_request.py
+++ b/robosystems_client/models/backup_create_request.py
@@ -19,7 +19,9 @@ class BackupCreateRequest:
       backup_format (str | Unset): Backup format - only 'full_dump' is supported (complete .lbug database file)
           Default: 'full_dump'.
       backup_type (str | Unset): Backup type - only 'full' is supported Default: 'full'.
-      retention_days (int | Unset): Retention period in days Default: 30.
+      retention_days (int | Unset): Retention period in days, further capped to the graph tier's maximum (7/30/90). 90
+          is the hard ceiling: the storage lifecycle expires backup objects then regardless of the requested value.
+          Default: 30.
       compression (bool | Unset): Enable compression (always enabled for optimal storage) Default: True.
       encryption (bool | Unset): Enable encryption (encrypted backups cannot be downloaded) Default: False.
       schedule (None | str | Unset): Optional cron schedule for automated backups

--- a/robosystems_client/models/graph_limits_response.py
+++ b/robosystems_client/models/graph_limits_response.py
@@ -28,7 +28,7 @@ class GraphLimitsResponse:
 
   Attributes:
       graph_id (str): Graph database identifier
-      subscription_tier (str): User's subscription tier
+      subscription_tier (str): Rate-limit tier enforced for requests to this graph
       graph_tier (str): Graph's database tier
       is_shared_repository (bool): Whether this is a shared repository
       storage (StorageLimits): Storage limits information.

--- a/robosystems_client/models/graph_tier_instance.py
+++ b/robosystems_client/models/graph_tier_instance.py
@@ -15,7 +15,8 @@ class GraphTierInstance:
 
   Attributes:
       type_ (str): Instance type identifier
-      memory_mb (int): Memory allocated to your graph in megabytes
+      memory_mb (int): LadybugDB memory budget for the whole instance in megabytes (below physical RAM after OS
+          overhead; not a per-graph allocation)
       is_multitenant (bool): Whether this tier shares infrastructure with other graphs
   """
 

--- a/robosystems_client/models/list_subgraphs_response.py
+++ b/robosystems_client/models/list_subgraphs_response.py
@@ -23,7 +23,7 @@ class ListSubgraphsResponse:
       parent_graph_id (str): Parent graph identifier
       parent_graph_name (str): Parent graph name
       parent_graph_tier (str): Parent graph tier
-      subgraphs_enabled (bool): Whether subgraphs are enabled for this tier (requires Large/XLarge tier)
+      subgraphs_enabled (bool): Whether subgraphs are enabled for this tier
       subgraph_count (int): Total number of subgraphs
       subgraphs (list[SubgraphSummary]): List of subgraphs
       max_subgraphs (int | None | Unset): Maximum allowed subgraphs for this tier (None = unlimited)


### PR DESCRIPTION
## Summary

Regen picking up the backend's tier-claims cleanup (robosystems `bad33068`, `47a7bec6`) in the generated models. **Docstrings only** — no signatures, types or defaults change, so there is no runtime or call-site impact.

This brings the Python client level with the TypeScript client, which already carries all four of these descriptions as of its 0.5.12 regen.

## Changes

- **`backup_create_request.py`** — `retention_days` now records that the requested value is further capped by the graph tier's maximum (7/30/90), and that 90 is a hard ceiling the storage lifecycle enforces regardless of what's asked for.
- **`graph_limits_response.py`** — `subscription_tier` is the *rate-limit tier enforced for requests to this graph*, not the user's subscription tier. The old wording invited exactly the wrong inference.
- **`graph_tier_instance.py`** — `memory_mb` is the LadybugDB budget for the whole instance (below physical RAM after OS overhead), not a per-graph allocation.
- **`list_subgraphs_response.py`** — drops the "requires Large/XLarge tier" claim from `subgraphs_enabled`, which no longer reflects what's enforced.

## Testing

`just test-all` green: 439 passed / 17 skipped, ruff check, ruff format --check (827 files), and basedpyright at 0 errors / 0 warnings. The pre-commit hook ran the same suite.

## ⚠️ Note for whoever regenerates next

**The deployed API has not shipped these backend commits yet.** I checked `https://api.robosystems.ai/openapi.json` directly and it still returns the old text for three of the four fields:

| Field | Prod currently returns |
|---|---|
| `BackupCreateRequest.retention_days` | "Retention period in days" |
| `GraphLimitsResponse.subscription_tier` | "User's subscription tier" |
| `GraphTierInstance.memory_mb` | "Memory allocated to your graph in megabytes" |

(The fourth, `subgraphs_enabled`, is also old in prod — the new text is a substring of the old, so a naive check reports a false match.)

So `just generate-sdk` with its default or against prod **would revert this PR**. Regenerate against a backend running `main` until prod catches up. Worth re-checking once the tier commits deploy.

## Notes

- Verified before committing rather than assumed: I confirmed the TypeScript client already carries all four descriptions verbatim (`types.gen.ts` lines 532, 5629, 6176, 7652), so the two clients now agree.
- Version numbering between the clients is offset — Python 0.5.10 corresponds to TypeScript 0.5.12 — but the regen content is in lockstep after this. Publishing this needs a release, which is yours to cut.
