### PR TITLE
chore(sdk): regen — typed oauthCallback and liveFinancialStatement responses

### DIFF
--- a/robosystems_client/api/connections/oauth_callback.py
+++ b/robosystems_client/api/connections/oauth_callback.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...models.o_auth_callback_request import OAuthCallbackRequest
+from ...models.o_auth_callback_response import OAuthCallbackResponse
 from ...types import Response
 
 
@@ -38,9 +39,10 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | ErrorResponse | HTTPValidationError | None:
+) -> ErrorResponse | HTTPValidationError | OAuthCallbackResponse | None:
   if response.status_code == 200:
-    response_200 = response.json()
+    response_200 = OAuthCallbackResponse.from_dict(response.json())
+
     return response_200
 
   if response.status_code == 400:
@@ -86,7 +88,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | ErrorResponse | HTTPValidationError]:
+) -> Response[ErrorResponse | HTTPValidationError | OAuthCallbackResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -101,7 +103,7 @@ def sync_detailed(
   *,
   client: AuthenticatedClient,
   body: OAuthCallbackRequest,
-) -> Response[Any | ErrorResponse | HTTPValidationError]:
+) -> Response[ErrorResponse | HTTPValidationError | OAuthCallbackResponse]:
   """OAuth Callback
 
    Completes the OAuth authorization flow after provider redirect. Exchanges the authorization code for
@@ -118,7 +120,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | ErrorResponse | HTTPValidationError]
+      Response[ErrorResponse | HTTPValidationError | OAuthCallbackResponse]
   """
 
   kwargs = _get_kwargs(
@@ -140,7 +142,7 @@ def sync(
   *,
   client: AuthenticatedClient,
   body: OAuthCallbackRequest,
-) -> Any | ErrorResponse | HTTPValidationError | None:
+) -> ErrorResponse | HTTPValidationError | OAuthCallbackResponse | None:
   """OAuth Callback
 
    Completes the OAuth authorization flow after provider redirect. Exchanges the authorization code for
@@ -157,7 +159,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | ErrorResponse | HTTPValidationError
+      ErrorResponse | HTTPValidationError | OAuthCallbackResponse
   """
 
   return sync_detailed(
@@ -174,7 +176,7 @@ async def asyncio_detailed(
   *,
   client: AuthenticatedClient,
   body: OAuthCallbackRequest,
-) -> Response[Any | ErrorResponse | HTTPValidationError]:
+) -> Response[ErrorResponse | HTTPValidationError | OAuthCallbackResponse]:
   """OAuth Callback
 
    Completes the OAuth authorization flow after provider redirect. Exchanges the authorization code for
@@ -191,7 +193,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[Any | ErrorResponse | HTTPValidationError]
+      Response[ErrorResponse | HTTPValidationError | OAuthCallbackResponse]
   """
 
   kwargs = _get_kwargs(
@@ -211,7 +213,7 @@ async def asyncio(
   *,
   client: AuthenticatedClient,
   body: OAuthCallbackRequest,
-) -> Any | ErrorResponse | HTTPValidationError | None:
+) -> ErrorResponse | HTTPValidationError | OAuthCallbackResponse | None:
   """OAuth Callback
 
    Completes the OAuth authorization flow after provider redirect. Exchanges the authorization code for
@@ -228,7 +230,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Any | ErrorResponse | HTTPValidationError
+      ErrorResponse | HTTPValidationError | OAuthCallbackResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/live_financial_statement.py
+++ b/robosystems_client/api/extensions_robo_ledger/live_financial_statement.py
@@ -8,7 +8,9 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.live_financial_statement_request import LiveFinancialStatementRequest
-from ...models.operation_envelope import OperationEnvelope
+from ...models.operation_envelope_live_financial_statement_response import (
+  OperationEnvelopeLiveFinancialStatementResponse,
+)
 from ...types import UNSET, Response, Unset
 
 
@@ -39,9 +41,11 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse | None:
   if response.status_code == 200:
-    response_200 = OperationEnvelope.from_dict(response.json())
+    response_200 = OperationEnvelopeLiveFinancialStatementResponse.from_dict(
+      response.json()
+    )
 
     return response_200
 
@@ -93,7 +97,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -108,7 +112,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse]:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -130,7 +134,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse]
   """
 
   kwargs = _get_kwargs(
@@ -152,7 +156,7 @@ def sync(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse | None:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -174,7 +178,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | OperationEnvelope
+      ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse
   """
 
   return sync_detailed(
@@ -191,7 +195,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse]:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -213,7 +217,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse]
   """
 
   kwargs = _get_kwargs(
@@ -233,7 +237,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: LiveFinancialStatementRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse | None:
   """Live Financial Statement
 
    Generate an ad-hoc financial statement directly from the tenant's OLTP ledger data using the active
@@ -255,7 +259,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | OperationEnvelope
+      ErrorResponse | OperationEnvelopeLiveFinancialStatementResponse
   """
 
   return (

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -313,6 +313,8 @@ from .list_org_graphs_response_200_item import ListOrgGraphsResponse200Item
 from .list_subgraphs_response import ListSubgraphsResponse
 from .list_table_files_response import ListTableFilesResponse
 from .live_financial_statement_request import LiveFinancialStatementRequest
+from .live_financial_statement_response import LiveFinancialStatementResponse
+from .live_statement_fact_row import LiveStatementFactRow
 from .login_request import LoginRequest
 from .logout_user_response_logoutuser import LogoutUserResponseLogoutuser
 from .materialize_op import MaterializeOp
@@ -326,6 +328,7 @@ from .memory_record import MemoryRecord
 from .memory_record_provenance_type_0 import MemoryRecordProvenanceType0
 from .metric_mechanics import MetricMechanics
 from .o_auth_callback_request import OAuthCallbackRequest
+from .o_auth_callback_response import OAuthCallbackResponse
 from .o_auth_init_request import OAuthInitRequest
 from .o_auth_init_request_additional_params_type_0 import (
   OAuthInitRequestAdditionalParamsType0,
@@ -464,6 +467,12 @@ from .operation_envelope_ledger_entity_response import (
 )
 from .operation_envelope_ledger_entity_response_status import (
   OperationEnvelopeLedgerEntityResponseStatus,
+)
+from .operation_envelope_live_financial_statement_response import (
+  OperationEnvelopeLiveFinancialStatementResponse,
+)
+from .operation_envelope_live_financial_statement_response_status import (
+  OperationEnvelopeLiveFinancialStatementResponseStatus,
 )
 from .operation_envelope_portfolio_block_envelope import (
   OperationEnvelopePortfolioBlockEnvelope,
@@ -1062,6 +1071,8 @@ __all__ = (
   "ListSubgraphsResponse",
   "ListTableFilesResponse",
   "LiveFinancialStatementRequest",
+  "LiveFinancialStatementResponse",
+  "LiveStatementFactRow",
   "LoginRequest",
   "LogoutUserResponseLogoutuser",
   "MaterializeOp",
@@ -1075,6 +1086,7 @@ __all__ = (
   "MemoryRecordProvenanceType0",
   "MetricMechanics",
   "OAuthCallbackRequest",
+  "OAuthCallbackResponse",
   "OAuthInitRequest",
   "OAuthInitRequestAdditionalParamsType0",
   "OAuthInitResponse",
@@ -1130,6 +1142,8 @@ __all__ = (
   "OperationEnvelopeLedgerEntityResponseStatus",
   "OperationEnvelopelistPublishListMemberResponse",
   "OperationEnvelopelistPublishListMemberResponseStatus",
+  "OperationEnvelopeLiveFinancialStatementResponse",
+  "OperationEnvelopeLiveFinancialStatementResponseStatus",
   "OperationEnvelopePortfolioBlockEnvelope",
   "OperationEnvelopePortfolioBlockEnvelopeStatus",
   "OperationEnvelopePreviewEventBlockResponse",

--- a/robosystems_client/models/live_financial_statement_response.py
+++ b/robosystems_client/models/live_financial_statement_response.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.live_statement_fact_row import LiveStatementFactRow
+  from ..models.period_spec import PeriodSpec
+
+
+T = TypeVar("T", bound="LiveFinancialStatementResponse")
+
+
+@_attrs_define
+class LiveFinancialStatementResponse:
+  """Rendered OLTP-backed ad-hoc statement.
+
+  Attributes:
+      graph_id (str):
+      statement_type (str):
+      periods (list[PeriodSpec]):
+      facts (list[LiveStatementFactRow]):
+      fact_count (int):
+      unmapped_count (int | Unset):  Default: 0.
+      truncated (bool | Unset):  Default: False.
+  """
+
+  graph_id: str
+  statement_type: str
+  periods: list[PeriodSpec]
+  facts: list[LiveStatementFactRow]
+  fact_count: int
+  unmapped_count: int | Unset = 0
+  truncated: bool | Unset = False
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    graph_id = self.graph_id
+
+    statement_type = self.statement_type
+
+    periods = []
+    for periods_item_data in self.periods:
+      periods_item = periods_item_data.to_dict()
+      periods.append(periods_item)
+
+    facts = []
+    for facts_item_data in self.facts:
+      facts_item = facts_item_data.to_dict()
+      facts.append(facts_item)
+
+    fact_count = self.fact_count
+
+    unmapped_count = self.unmapped_count
+
+    truncated = self.truncated
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "graph_id": graph_id,
+        "statement_type": statement_type,
+        "periods": periods,
+        "facts": facts,
+        "fact_count": fact_count,
+      }
+    )
+    if unmapped_count is not UNSET:
+      field_dict["unmapped_count"] = unmapped_count
+    if truncated is not UNSET:
+      field_dict["truncated"] = truncated
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.live_statement_fact_row import LiveStatementFactRow
+    from ..models.period_spec import PeriodSpec
+
+    d = dict(src_dict)
+    graph_id = d.pop("graph_id")
+
+    statement_type = d.pop("statement_type")
+
+    periods = []
+    _periods = d.pop("periods")
+    for periods_item_data in _periods:
+      periods_item = PeriodSpec.from_dict(periods_item_data)
+
+      periods.append(periods_item)
+
+    facts = []
+    _facts = d.pop("facts")
+    for facts_item_data in _facts:
+      facts_item = LiveStatementFactRow.from_dict(facts_item_data)
+
+      facts.append(facts_item)
+
+    fact_count = d.pop("fact_count")
+
+    unmapped_count = d.pop("unmapped_count", UNSET)
+
+    truncated = d.pop("truncated", UNSET)
+
+    live_financial_statement_response = cls(
+      graph_id=graph_id,
+      statement_type=statement_type,
+      periods=periods,
+      facts=facts,
+      fact_count=fact_count,
+      unmapped_count=unmapped_count,
+      truncated=truncated,
+    )
+
+    live_financial_statement_response.additional_properties = d
+    return live_financial_statement_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/live_statement_fact_row.py
+++ b/robosystems_client/models/live_statement_fact_row.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LiveStatementFactRow")
+
+
+@_attrs_define
+class LiveStatementFactRow:
+  """A single row of an OLTP-backed ad-hoc statement.
+
+  Attributes:
+      qname (str):
+      name (str):
+      values (list[float | None]):
+      trait (None | str | Unset):
+      depth (int | Unset):  Default: 0.
+      is_subtotal (bool | Unset):  Default: False.
+  """
+
+  qname: str
+  name: str
+  values: list[float | None]
+  trait: None | str | Unset = UNSET
+  depth: int | Unset = 0
+  is_subtotal: bool | Unset = False
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    qname = self.qname
+
+    name = self.name
+
+    values = []
+    for values_item_data in self.values:
+      values_item: float | None
+      values_item = values_item_data
+      values.append(values_item)
+
+    trait: None | str | Unset
+    if isinstance(self.trait, Unset):
+      trait = UNSET
+    else:
+      trait = self.trait
+
+    depth = self.depth
+
+    is_subtotal = self.is_subtotal
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "qname": qname,
+        "name": name,
+        "values": values,
+      }
+    )
+    if trait is not UNSET:
+      field_dict["trait"] = trait
+    if depth is not UNSET:
+      field_dict["depth"] = depth
+    if is_subtotal is not UNSET:
+      field_dict["is_subtotal"] = is_subtotal
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    qname = d.pop("qname")
+
+    name = d.pop("name")
+
+    values = []
+    _values = d.pop("values")
+    for values_item_data in _values:
+
+      def _parse_values_item(data: object) -> float | None:
+        if data is None:
+          return data
+        return cast(float | None, data)
+
+      values_item = _parse_values_item(values_item_data)
+
+      values.append(values_item)
+
+    def _parse_trait(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    trait = _parse_trait(d.pop("trait", UNSET))
+
+    depth = d.pop("depth", UNSET)
+
+    is_subtotal = d.pop("is_subtotal", UNSET)
+
+    live_statement_fact_row = cls(
+      qname=qname,
+      name=name,
+      values=values,
+      trait=trait,
+      depth=depth,
+      is_subtotal=is_subtotal,
+    )
+
+    live_statement_fact_row.additional_properties = d
+    return live_statement_fact_row
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/o_auth_callback_response.py
+++ b/robosystems_client/models/o_auth_callback_response.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OAuthCallbackResponse")
+
+
+@_attrs_define
+class OAuthCallbackResponse:
+  """Result of completing an OAuth authorization flow.
+
+  Attributes:
+      success (bool): Whether the connection was established
+      message (str): Human-readable outcome of the exchange
+      connection_id (str): Connection the authorization was linked to
+      auto_sync_task_id (None | str | Unset): Task id of the initial sync started after connecting, or null when no
+          sync was kicked off
+  """
+
+  success: bool
+  message: str
+  connection_id: str
+  auto_sync_task_id: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    success = self.success
+
+    message = self.message
+
+    connection_id = self.connection_id
+
+    auto_sync_task_id: None | str | Unset
+    if isinstance(self.auto_sync_task_id, Unset):
+      auto_sync_task_id = UNSET
+    else:
+      auto_sync_task_id = self.auto_sync_task_id
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "success": success,
+        "message": message,
+        "connection_id": connection_id,
+      }
+    )
+    if auto_sync_task_id is not UNSET:
+      field_dict["auto_sync_task_id"] = auto_sync_task_id
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    success = d.pop("success")
+
+    message = d.pop("message")
+
+    connection_id = d.pop("connection_id")
+
+    def _parse_auto_sync_task_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    auto_sync_task_id = _parse_auto_sync_task_id(d.pop("auto_sync_task_id", UNSET))
+
+    o_auth_callback_response = cls(
+      success=success,
+      message=message,
+      connection_id=connection_id,
+      auto_sync_task_id=auto_sync_task_id,
+    )
+
+    o_auth_callback_response.additional_properties = d
+    return o_auth_callback_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_live_financial_statement_response.py
+++ b/robosystems_client/models/operation_envelope_live_financial_statement_response.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.operation_envelope_live_financial_statement_response_status import (
+  OperationEnvelopeLiveFinancialStatementResponseStatus,
+)
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.live_financial_statement_response import LiveFinancialStatementResponse
+
+
+T = TypeVar("T", bound="OperationEnvelopeLiveFinancialStatementResponse")
+
+
+@_attrs_define
+class OperationEnvelopeLiveFinancialStatementResponse:
+  """
+  Attributes:
+      operation (str): Kebab-case operation name
+      operation_id (str): op_-prefixed ULID for audit and SSE correlation
+      status (OperationEnvelopeLiveFinancialStatementResponseStatus): Operation lifecycle state
+      at (str): ISO-8601 UTC timestamp
+      result (LiveFinancialStatementResponse | None | Unset): Command-specific result payload
+      created_by (None | str | Unset): User ID that initiated the operation (null for legacy callers)
+      idempotent_replay (bool | Unset): True when this envelope came from the idempotency cache — the underlying
+          command did not execute again. False on fresh executions. Default: False.
+  """
+
+  operation: str
+  operation_id: str
+  status: OperationEnvelopeLiveFinancialStatementResponseStatus
+  at: str
+  result: LiveFinancialStatementResponse | None | Unset = UNSET
+  created_by: None | str | Unset = UNSET
+  idempotent_replay: bool | Unset = False
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.live_financial_statement_response import (
+      LiveFinancialStatementResponse,
+    )
+
+    operation = self.operation
+
+    operation_id = self.operation_id
+
+    status = self.status.value
+
+    at = self.at
+
+    result: dict[str, Any] | None | Unset
+    if isinstance(self.result, Unset):
+      result = UNSET
+    elif isinstance(self.result, LiveFinancialStatementResponse):
+      result = self.result.to_dict()
+    else:
+      result = self.result
+
+    created_by: None | str | Unset
+    if isinstance(self.created_by, Unset):
+      created_by = UNSET
+    else:
+      created_by = self.created_by
+
+    idempotent_replay = self.idempotent_replay
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "operation": operation,
+        "operationId": operation_id,
+        "status": status,
+        "at": at,
+      }
+    )
+    if result is not UNSET:
+      field_dict["result"] = result
+    if created_by is not UNSET:
+      field_dict["createdBy"] = created_by
+    if idempotent_replay is not UNSET:
+      field_dict["idempotentReplay"] = idempotent_replay
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.live_financial_statement_response import (
+      LiveFinancialStatementResponse,
+    )
+
+    d = dict(src_dict)
+    operation = d.pop("operation")
+
+    operation_id = d.pop("operationId")
+
+    status = OperationEnvelopeLiveFinancialStatementResponseStatus(d.pop("status"))
+
+    at = d.pop("at")
+
+    def _parse_result(data: object) -> LiveFinancialStatementResponse | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        result_type_0 = LiveFinancialStatementResponse.from_dict(data)
+
+        return result_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(LiveFinancialStatementResponse | None | Unset, data)
+
+    result = _parse_result(d.pop("result", UNSET))
+
+    def _parse_created_by(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    created_by = _parse_created_by(d.pop("createdBy", UNSET))
+
+    idempotent_replay = d.pop("idempotentReplay", UNSET)
+
+    operation_envelope_live_financial_statement_response = cls(
+      operation=operation,
+      operation_id=operation_id,
+      status=status,
+      at=at,
+      result=result,
+      created_by=created_by,
+      idempotent_replay=idempotent_replay,
+    )
+
+    operation_envelope_live_financial_statement_response.additional_properties = d
+    return operation_envelope_live_financial_statement_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_live_financial_statement_response_status.py
+++ b/robosystems_client/models/operation_envelope_live_financial_statement_response_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class OperationEnvelopeLiveFinancialStatementResponseStatus(str, Enum):
+  COMPLETED = "completed"
+  FAILED = "failed"
+  PENDING = "pending"
+
+  def __str__(self) -> str:
+    return str(self.value)


### PR DESCRIPTION
## Summary

Regen picking up [robosystems#955](https://github.com/RoboFinSystems/robosystems/pull/955), which declared response models for two routes that were previously undescribed in the OpenAPI schema. Parity with the matching TypeScript regen in robosystems-typescript-client#161.

- **`oauth_callback`** — the parsed 200 becomes `OAuthCallbackResponse` (`{success, message, connection_id, auto_sync_task_id}`) instead of an untyped body.
- **`live_financial_statement`** — the parsed 200 becomes `OperationEnvelopeLiveFinancialStatementResponse`, whose `result` is a typed `LiveFinancialStatementResponse` rather than an unstructured payload.

## Changes

Modified:
- `api/connections/oauth_callback.py` — `_parse_response` and the sync/async wrappers now return `OAuthCallbackResponse` in the union.
- `api/extensions_robo_ledger/live_financial_statement.py` — same, for the typed envelope.
- `models/__init__.py` — exports the new models.

Added (generated):
- `models/o_auth_callback_response.py`
- `models/live_financial_statement_response.py`
- `models/live_statement_fact_row.py`
- `models/operation_envelope_live_financial_statement_response.py`
- `models/operation_envelope_live_financial_statement_response_status.py`

## Testing

`just test-all` green — 439 passed / 17 skipped, ruff check, ruff format --check (832 files), basedpyright 0 errors / 0 warnings. The pre-commit hook ran the same suite.

## Notes

- The regen surfaced no reverts: the tier claim descriptions merged in #150 are untouched here, since this client is already current on them.
- Publishing needs a release, which is yours to cut.
