### PR TITLE
fix(ledger): surface the typed live_financial_statement result

### DIFF
--- a/robosystems_client/clients/ledger_client.py
+++ b/robosystems_client/clients/ledger_client.py
@@ -248,6 +248,7 @@ from ..models.financial_statement_analysis_request import (
   FinancialStatementAnalysisRequest,
 )
 from ..models.live_financial_statement_request import LiveFinancialStatementRequest
+from ..models.live_financial_statement_response import LiveFinancialStatementResponse
 from ..models.update_agent_request import UpdateAgentRequest
 from ..models.update_event_block_request import UpdateEventBlockRequest
 from ..models.update_event_handler_request import UpdateEventHandlerRequest
@@ -1576,7 +1577,7 @@ class LedgerClient:
     self,
     graph_id: str,
     body: dict[str, Any],
-  ) -> dict[str, Any]:
+  ) -> LiveFinancialStatementResponse:
     """Live financial statement — pulls facts directly from the graph for
     an explicit period window (or fiscal year) and returns the statement
     shape without a persisted Report row. Useful for ad-hoc previews and
@@ -1587,7 +1588,9 @@ class LedgerClient:
       graph_id=graph_id, body=request, client=self._get_client()
     )
     envelope = self._call_op("Live financial statement", response)
-    return envelope.result or {}
+    return self._typed_result(
+      "Live financial statement", envelope, LiveFinancialStatementResponse
+    )
 
   def financial_statement_analysis(
     self,


### PR DESCRIPTION
## Summary

Yes — the Python client had the identical gap. Mirror of [robosystems-typescript-client#162](https://github.com/RoboFinSystems/robosystems-typescript-client/pull/162).

The 0.5.11 regen (#151) typed the *generated* op — its envelope `result` is now `LiveFinancialStatementResponse` instead of an unstructured payload. But the hand-written facade still declared `dict[str, Any]` and returned `envelope.result or {}`, so **the type stopped at the generated layer and never reached callers**. Same shape of bug as the TypeScript one, found by checking rather than assuming the regen was sufficient.

## Change

```diff
-  ) -> dict[str, Any]:
+  ) -> LiveFinancialStatementResponse:
     ...
     envelope = self._call_op("Live financial statement", response)
-    return envelope.result or {}
+    return self._typed_result(
+      "Live financial statement", envelope, LiveFinancialStatementResponse
+    )
```

`_typed_result` is what every other typed-envelope facade method in this class already uses (`EventHandlerResponse`, `ReportResponse`, `TaxonomyBlockEnvelope`, …), so this brings `live_financial_statement` in line rather than inventing a pattern.

## One edge worth recording

`_typed_result` normalises a missing result to the legacy `{"deleted": True}` delete sentinel, whereas this method previously returned `{}`. Neither is meaningful for a statement read.

I checked before adopting it: the path is effectively unreachable — `_call_op` already raises on any non-2xx, and a 200 now carries a typed result by contract. Flagging it rather than letting it land silently, since it *is* a behaviour change on a path that theoretically exists.

(The TypeScript equivalent, `requireResult`, throws instead. The two helpers differ here; unifying them isn't worth a breaking change to the Python delete-style ops that depend on the sentinel.)

## Scope

`financial_statement_analysis` and `build_fact_grid` keep `dict[str, Any]`, which remains **correct** — their backend routes aren't parameterised with a result type, so there's nothing typed to surface. They'd need the same backend treatment `liveFinancialStatement` got in robosystems#955 first.

## Testing

`just test-all` green — 439 passed / 17 skipped, ruff check, ruff format --check (832 files), basedpyright 0 errors / 0 warnings. Pre-commit hook ran the same suite.
