### PR TITLE
chore(sdk): regen for typed view results, and surface them in the facade

### DIFF
--- a/robosystems_client/api/extensions_robo_ledger/build_fact_grid.py
+++ b/robosystems_client/api/extensions_robo_ledger/build_fact_grid.py
@@ -8,7 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_view_request import CreateViewRequest
 from ...models.error_response import ErrorResponse
-from ...models.operation_envelope import OperationEnvelope
+from ...models.operation_envelope_view_response import OperationEnvelopeViewResponse
 from ...types import UNSET, Response, Unset
 
 
@@ -39,9 +39,9 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeViewResponse | None:
   if response.status_code == 200:
-    response_200 = OperationEnvelope.from_dict(response.json())
+    response_200 = OperationEnvelopeViewResponse.from_dict(response.json())
 
     return response_200
 
@@ -93,7 +93,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeViewResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -108,7 +108,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeViewResponse]:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -128,7 +128,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelopeViewResponse]
   """
 
   kwargs = _get_kwargs(
@@ -150,7 +150,7 @@ def sync(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeViewResponse | None:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -170,7 +170,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | OperationEnvelope
+      ErrorResponse | OperationEnvelopeViewResponse
   """
 
   return sync_detailed(
@@ -187,7 +187,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeViewResponse]:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -207,7 +207,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelopeViewResponse]
   """
 
   kwargs = _get_kwargs(
@@ -227,7 +227,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: CreateViewRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeViewResponse | None:
   """Build Fact Grid
 
    Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods,
@@ -247,7 +247,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | OperationEnvelope
+      ErrorResponse | OperationEnvelopeViewResponse
   """
 
   return (

--- a/robosystems_client/api/extensions_robo_ledger/financial_statement_analysis.py
+++ b/robosystems_client/api/extensions_robo_ledger/financial_statement_analysis.py
@@ -10,7 +10,9 @@ from ...models.error_response import ErrorResponse
 from ...models.financial_statement_analysis_request import (
   FinancialStatementAnalysisRequest,
 )
-from ...models.operation_envelope import OperationEnvelope
+from ...models.operation_envelope_financial_statement_analysis_response import (
+  OperationEnvelopeFinancialStatementAnalysisResponse,
+)
 from ...types import UNSET, Response, Unset
 
 
@@ -41,9 +43,11 @@ def _get_kwargs(
 
 def _parse_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse | None:
   if response.status_code == 200:
-    response_200 = OperationEnvelope.from_dict(response.json())
+    response_200 = OperationEnvelopeFinancialStatementAnalysisResponse.from_dict(
+      response.json()
+    )
 
     return response_200
 
@@ -95,7 +99,7 @@ def _parse_response(
 
 def _build_response(
   *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse]:
   return Response(
     status_code=HTTPStatus(response.status_code),
     content=response.content,
@@ -110,7 +114,7 @@ def sync_detailed(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse]:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -132,7 +136,7 @@ def sync_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse]
   """
 
   kwargs = _get_kwargs(
@@ -154,7 +158,7 @@ def sync(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse | None:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -176,7 +180,7 @@ def sync(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | OperationEnvelope
+      ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse
   """
 
   return sync_detailed(
@@ -193,7 +197,7 @@ async def asyncio_detailed(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> Response[ErrorResponse | OperationEnvelope]:
+) -> Response[ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse]:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -215,7 +219,7 @@ async def asyncio_detailed(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      Response[ErrorResponse | OperationEnvelope]
+      Response[ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse]
   """
 
   kwargs = _get_kwargs(
@@ -235,7 +239,7 @@ async def asyncio(
   client: AuthenticatedClient,
   body: FinancialStatementAnalysisRequest,
   idempotency_key: None | str | Unset = UNSET,
-) -> ErrorResponse | OperationEnvelope | None:
+) -> ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse | None:
   """Financial Statement Analysis
 
    Query a rendered financial statement from the graph-backed XBRL hypercube (Structure → FactSet →
@@ -257,7 +261,7 @@ async def asyncio(
       httpx.TimeoutException: If the request takes longer than Client.timeout.
 
   Returns:
-      ErrorResponse | OperationEnvelope
+      ErrorResponse | OperationEnvelopeFinancialStatementAnalysisResponse
   """
 
   return (

--- a/robosystems_client/clients/ledger_client.py
+++ b/robosystems_client/clients/ledger_client.py
@@ -248,7 +248,11 @@ from ..models.financial_statement_analysis_request import (
   FinancialStatementAnalysisRequest,
 )
 from ..models.live_financial_statement_request import LiveFinancialStatementRequest
+from ..models.financial_statement_analysis_response import (
+  FinancialStatementAnalysisResponse,
+)
 from ..models.live_financial_statement_response import LiveFinancialStatementResponse
+from ..models.view_response import ViewResponse
 from ..models.update_agent_request import UpdateAgentRequest
 from ..models.update_event_block_request import UpdateEventBlockRequest
 from ..models.update_event_handler_request import UpdateEventHandlerRequest
@@ -1596,7 +1600,7 @@ class LedgerClient:
     self,
     graph_id: str,
     body: dict[str, Any],
-  ) -> dict[str, Any]:
+  ) -> FinancialStatementAnalysisResponse:
     """Run a financial statement analysis against an existing report.
 
     On shared-repo graphs (e.g. SEC), ``ticker`` is required; on tenant
@@ -1608,11 +1612,13 @@ class LedgerClient:
       graph_id=graph_id, body=request, client=self._get_client()
     )
     envelope = self._call_op("Financial statement analysis", response)
-    return envelope.result or {}
+    return self._typed_result(
+      "Financial statement analysis", envelope, FinancialStatementAnalysisResponse
+    )
 
   # ── Fact grid (graph-backed analytical query) ─────────────────────
 
-  def build_fact_grid(self, graph_id: str, request: dict[str, Any]) -> dict[str, Any]:
+  def build_fact_grid(self, graph_id: str, request: dict[str, Any]) -> ViewResponse:
     """Build a multi-dimensional fact grid against the graph schema.
 
     This is a graph-database *read* dispatched through the operation
@@ -1635,7 +1641,7 @@ class LedgerClient:
       graph_id=graph_id, body=body, client=self._get_client()
     )
     envelope = self._call_op("Build fact grid", response)
-    return envelope.result or {}
+    return self._typed_result("Build fact grid", envelope, ViewResponse)
 
   # ── Closing book ───────────────────────────────────────────────────
 

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .account_info import AccountInfo
 from .add_publish_list_members_operation import AddPublishListMembersOperation
+from .analytical_statement_fact_row import AnalyticalStatementFactRow
 from .api_key_info import APIKeyInfo
 from .api_keys_response import APIKeysResponse
 from .artifact_response import ArtifactResponse
@@ -222,6 +223,7 @@ from .file_layer_status import FileLayerStatus
 from .file_report_request import FileReportRequest
 from .file_upload_request import FileUploadRequest
 from .financial_statement_analysis_request import FinancialStatementAnalysisRequest
+from .financial_statement_analysis_response import FinancialStatementAnalysisResponse
 from .fiscal_calendar_response import FiscalCalendarResponse
 from .fiscal_period_summary import FiscalPeriodSummary
 from .forecast_mechanics import ForecastMechanics
@@ -432,6 +434,12 @@ from .operation_envelope_execute_event_block_response import (
 from .operation_envelope_execute_event_block_response_status import (
   OperationEnvelopeExecuteEventBlockResponseStatus,
 )
+from .operation_envelope_financial_statement_analysis_response import (
+  OperationEnvelopeFinancialStatementAnalysisResponse,
+)
+from .operation_envelope_financial_statement_analysis_response_status import (
+  OperationEnvelopeFinancialStatementAnalysisResponseStatus,
+)
 from .operation_envelope_fiscal_calendar_response import (
   OperationEnvelopeFiscalCalendarResponse,
 )
@@ -525,6 +533,8 @@ from .operation_envelope_taxonomy_block_envelope import (
 from .operation_envelope_taxonomy_block_envelope_status import (
   OperationEnvelopeTaxonomyBlockEnvelopeStatus,
 )
+from .operation_envelope_view_response import OperationEnvelopeViewResponse
+from .operation_envelope_view_response_status import OperationEnvelopeViewResponseStatus
 from .operation_envelopelist_publish_list_member_response import (
   OperationEnvelopelistPublishListMemberResponse,
 )
@@ -622,6 +632,7 @@ from .resend_verification_email_response_resendverificationemail import (
 )
 from .reset_password_request import ResetPasswordRequest
 from .reset_password_validate_response import ResetPasswordValidateResponse
+from .resolved_report_info import ResolvedReportInfo
 from .response_mode import ResponseMode
 from .restore_backup_op import RestoreBackupOp
 from .rollforward_mechanics import RollforwardMechanics
@@ -811,11 +822,15 @@ from .view_axis_config import ViewAxisConfig
 from .view_axis_config_element_labels_type_0 import ViewAxisConfigElementLabelsType0
 from .view_axis_config_member_labels_type_0 import ViewAxisConfigMemberLabelsType0
 from .view_config import ViewConfig
+from .view_metadata import ViewMetadata
 from .view_projections import ViewProjections
+from .view_response import ViewResponse
+from .view_response_presentations import ViewResponsePresentations
 
 __all__ = (
   "AccountInfo",
   "AddPublishListMembersOperation",
+  "AnalyticalStatementFactRow",
   "APIKeyInfo",
   "APIKeysResponse",
   "ArtifactResponse",
@@ -998,6 +1013,7 @@ __all__ = (
   "FileReportRequest",
   "FileUploadRequest",
   "FinancialStatementAnalysisRequest",
+  "FinancialStatementAnalysisResponse",
   "FiscalCalendarResponse",
   "FiscalPeriodSummary",
   "ForecastMechanics",
@@ -1128,6 +1144,8 @@ __all__ = (
   "OperationEnvelopeEventHandlerResponseStatus",
   "OperationEnvelopeExecuteEventBlockResponse",
   "OperationEnvelopeExecuteEventBlockResponseStatus",
+  "OperationEnvelopeFinancialStatementAnalysisResponse",
+  "OperationEnvelopeFinancialStatementAnalysisResponseStatus",
   "OperationEnvelopeFiscalCalendarResponse",
   "OperationEnvelopeFiscalCalendarResponseStatus",
   "OperationEnvelopeInformationBlockEnvelope",
@@ -1163,6 +1181,8 @@ __all__ = (
   "OperationEnvelopeStatus",
   "OperationEnvelopeTaxonomyBlockEnvelope",
   "OperationEnvelopeTaxonomyBlockEnvelopeStatus",
+  "OperationEnvelopeViewResponse",
+  "OperationEnvelopeViewResponseStatus",
   "OperationError",
   "OperationErrorDetailType1",
   "OperatorListResponse",
@@ -1244,6 +1264,7 @@ __all__ = (
   "ResendVerificationEmailResponseResendverificationemail",
   "ResetPasswordRequest",
   "ResetPasswordValidateResponse",
+  "ResolvedReportInfo",
   "ResponseMode",
   "RestoreBackupOp",
   "RollforwardMechanics",
@@ -1389,5 +1410,8 @@ __all__ = (
   "ViewAxisConfigElementLabelsType0",
   "ViewAxisConfigMemberLabelsType0",
   "ViewConfig",
+  "ViewMetadata",
   "ViewProjections",
+  "ViewResponse",
+  "ViewResponsePresentations",
 )

--- a/robosystems_client/models/analytical_statement_fact_row.py
+++ b/robosystems_client/models/analytical_statement_fact_row.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AnalyticalStatementFactRow")
+
+
+@_attrs_define
+class AnalyticalStatementFactRow:
+  """A single fact row from the graph-backed statement analysis.
+
+  Attributes:
+      qname (str):
+      name (str):
+      canonical_concept (None | str | Unset):
+      value (float | None | Unset):
+      end_date (None | str | Unset):
+      period_type (None | str | Unset):
+      duration_type (None | str | Unset):
+  """
+
+  qname: str
+  name: str
+  canonical_concept: None | str | Unset = UNSET
+  value: float | None | Unset = UNSET
+  end_date: None | str | Unset = UNSET
+  period_type: None | str | Unset = UNSET
+  duration_type: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    qname = self.qname
+
+    name = self.name
+
+    canonical_concept: None | str | Unset
+    if isinstance(self.canonical_concept, Unset):
+      canonical_concept = UNSET
+    else:
+      canonical_concept = self.canonical_concept
+
+    value: float | None | Unset
+    if isinstance(self.value, Unset):
+      value = UNSET
+    else:
+      value = self.value
+
+    end_date: None | str | Unset
+    if isinstance(self.end_date, Unset):
+      end_date = UNSET
+    else:
+      end_date = self.end_date
+
+    period_type: None | str | Unset
+    if isinstance(self.period_type, Unset):
+      period_type = UNSET
+    else:
+      period_type = self.period_type
+
+    duration_type: None | str | Unset
+    if isinstance(self.duration_type, Unset):
+      duration_type = UNSET
+    else:
+      duration_type = self.duration_type
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "qname": qname,
+        "name": name,
+      }
+    )
+    if canonical_concept is not UNSET:
+      field_dict["canonical_concept"] = canonical_concept
+    if value is not UNSET:
+      field_dict["value"] = value
+    if end_date is not UNSET:
+      field_dict["end_date"] = end_date
+    if period_type is not UNSET:
+      field_dict["period_type"] = period_type
+    if duration_type is not UNSET:
+      field_dict["duration_type"] = duration_type
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    qname = d.pop("qname")
+
+    name = d.pop("name")
+
+    def _parse_canonical_concept(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    canonical_concept = _parse_canonical_concept(d.pop("canonical_concept", UNSET))
+
+    def _parse_value(data: object) -> float | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(float | None | Unset, data)
+
+    value = _parse_value(d.pop("value", UNSET))
+
+    def _parse_end_date(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    end_date = _parse_end_date(d.pop("end_date", UNSET))
+
+    def _parse_period_type(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    period_type = _parse_period_type(d.pop("period_type", UNSET))
+
+    def _parse_duration_type(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    duration_type = _parse_duration_type(d.pop("duration_type", UNSET))
+
+    analytical_statement_fact_row = cls(
+      qname=qname,
+      name=name,
+      canonical_concept=canonical_concept,
+      value=value,
+      end_date=end_date,
+      period_type=period_type,
+      duration_type=duration_type,
+    )
+
+    analytical_statement_fact_row.additional_properties = d
+    return analytical_statement_fact_row
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/financial_statement_analysis_response.py
+++ b/robosystems_client/models/financial_statement_analysis_response.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.analytical_statement_fact_row import AnalyticalStatementFactRow
+  from ..models.resolved_report_info import ResolvedReportInfo
+
+
+T = TypeVar("T", bound="FinancialStatementAnalysisResponse")
+
+
+@_attrs_define
+class FinancialStatementAnalysisResponse:
+  """Results of the financial-statement-analysis view op.
+
+  Attributes:
+      graph_id (str):
+      statement_type (str):
+      facts (list[AnalyticalStatementFactRow]):
+      fact_count (int):
+      ticker (None | str | Unset):
+      report_id (None | str | Unset):
+      resolved_report (None | ResolvedReportInfo | Unset):
+  """
+
+  graph_id: str
+  statement_type: str
+  facts: list[AnalyticalStatementFactRow]
+  fact_count: int
+  ticker: None | str | Unset = UNSET
+  report_id: None | str | Unset = UNSET
+  resolved_report: None | ResolvedReportInfo | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.resolved_report_info import ResolvedReportInfo
+
+    graph_id = self.graph_id
+
+    statement_type = self.statement_type
+
+    facts = []
+    for facts_item_data in self.facts:
+      facts_item = facts_item_data.to_dict()
+      facts.append(facts_item)
+
+    fact_count = self.fact_count
+
+    ticker: None | str | Unset
+    if isinstance(self.ticker, Unset):
+      ticker = UNSET
+    else:
+      ticker = self.ticker
+
+    report_id: None | str | Unset
+    if isinstance(self.report_id, Unset):
+      report_id = UNSET
+    else:
+      report_id = self.report_id
+
+    resolved_report: dict[str, Any] | None | Unset
+    if isinstance(self.resolved_report, Unset):
+      resolved_report = UNSET
+    elif isinstance(self.resolved_report, ResolvedReportInfo):
+      resolved_report = self.resolved_report.to_dict()
+    else:
+      resolved_report = self.resolved_report
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "graph_id": graph_id,
+        "statement_type": statement_type,
+        "facts": facts,
+        "fact_count": fact_count,
+      }
+    )
+    if ticker is not UNSET:
+      field_dict["ticker"] = ticker
+    if report_id is not UNSET:
+      field_dict["report_id"] = report_id
+    if resolved_report is not UNSET:
+      field_dict["resolved_report"] = resolved_report
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.analytical_statement_fact_row import AnalyticalStatementFactRow
+    from ..models.resolved_report_info import ResolvedReportInfo
+
+    d = dict(src_dict)
+    graph_id = d.pop("graph_id")
+
+    statement_type = d.pop("statement_type")
+
+    facts = []
+    _facts = d.pop("facts")
+    for facts_item_data in _facts:
+      facts_item = AnalyticalStatementFactRow.from_dict(facts_item_data)
+
+      facts.append(facts_item)
+
+    fact_count = d.pop("fact_count")
+
+    def _parse_ticker(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    ticker = _parse_ticker(d.pop("ticker", UNSET))
+
+    def _parse_report_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    report_id = _parse_report_id(d.pop("report_id", UNSET))
+
+    def _parse_resolved_report(data: object) -> None | ResolvedReportInfo | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        resolved_report_type_0 = ResolvedReportInfo.from_dict(data)
+
+        return resolved_report_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(None | ResolvedReportInfo | Unset, data)
+
+    resolved_report = _parse_resolved_report(d.pop("resolved_report", UNSET))
+
+    financial_statement_analysis_response = cls(
+      graph_id=graph_id,
+      statement_type=statement_type,
+      facts=facts,
+      fact_count=fact_count,
+      ticker=ticker,
+      report_id=report_id,
+      resolved_report=resolved_report,
+    )
+
+    financial_statement_analysis_response.additional_properties = d
+    return financial_statement_analysis_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_financial_statement_analysis_response.py
+++ b/robosystems_client/models/operation_envelope_financial_statement_analysis_response.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.operation_envelope_financial_statement_analysis_response_status import (
+  OperationEnvelopeFinancialStatementAnalysisResponseStatus,
+)
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.financial_statement_analysis_response import (
+    FinancialStatementAnalysisResponse,
+  )
+
+
+T = TypeVar("T", bound="OperationEnvelopeFinancialStatementAnalysisResponse")
+
+
+@_attrs_define
+class OperationEnvelopeFinancialStatementAnalysisResponse:
+  """
+  Attributes:
+      operation (str): Kebab-case operation name
+      operation_id (str): op_-prefixed ULID for audit and SSE correlation
+      status (OperationEnvelopeFinancialStatementAnalysisResponseStatus): Operation lifecycle state
+      at (str): ISO-8601 UTC timestamp
+      result (FinancialStatementAnalysisResponse | None | Unset): Command-specific result payload
+      created_by (None | str | Unset): User ID that initiated the operation (null for legacy callers)
+      idempotent_replay (bool | Unset): True when this envelope came from the idempotency cache — the underlying
+          command did not execute again. False on fresh executions. Default: False.
+  """
+
+  operation: str
+  operation_id: str
+  status: OperationEnvelopeFinancialStatementAnalysisResponseStatus
+  at: str
+  result: FinancialStatementAnalysisResponse | None | Unset = UNSET
+  created_by: None | str | Unset = UNSET
+  idempotent_replay: bool | Unset = False
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.financial_statement_analysis_response import (
+      FinancialStatementAnalysisResponse,
+    )
+
+    operation = self.operation
+
+    operation_id = self.operation_id
+
+    status = self.status.value
+
+    at = self.at
+
+    result: dict[str, Any] | None | Unset
+    if isinstance(self.result, Unset):
+      result = UNSET
+    elif isinstance(self.result, FinancialStatementAnalysisResponse):
+      result = self.result.to_dict()
+    else:
+      result = self.result
+
+    created_by: None | str | Unset
+    if isinstance(self.created_by, Unset):
+      created_by = UNSET
+    else:
+      created_by = self.created_by
+
+    idempotent_replay = self.idempotent_replay
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "operation": operation,
+        "operationId": operation_id,
+        "status": status,
+        "at": at,
+      }
+    )
+    if result is not UNSET:
+      field_dict["result"] = result
+    if created_by is not UNSET:
+      field_dict["createdBy"] = created_by
+    if idempotent_replay is not UNSET:
+      field_dict["idempotentReplay"] = idempotent_replay
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.financial_statement_analysis_response import (
+      FinancialStatementAnalysisResponse,
+    )
+
+    d = dict(src_dict)
+    operation = d.pop("operation")
+
+    operation_id = d.pop("operationId")
+
+    status = OperationEnvelopeFinancialStatementAnalysisResponseStatus(d.pop("status"))
+
+    at = d.pop("at")
+
+    def _parse_result(
+      data: object,
+    ) -> FinancialStatementAnalysisResponse | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        result_type_0 = FinancialStatementAnalysisResponse.from_dict(data)
+
+        return result_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(FinancialStatementAnalysisResponse | None | Unset, data)
+
+    result = _parse_result(d.pop("result", UNSET))
+
+    def _parse_created_by(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    created_by = _parse_created_by(d.pop("createdBy", UNSET))
+
+    idempotent_replay = d.pop("idempotentReplay", UNSET)
+
+    operation_envelope_financial_statement_analysis_response = cls(
+      operation=operation,
+      operation_id=operation_id,
+      status=status,
+      at=at,
+      result=result,
+      created_by=created_by,
+      idempotent_replay=idempotent_replay,
+    )
+
+    operation_envelope_financial_statement_analysis_response.additional_properties = d
+    return operation_envelope_financial_statement_analysis_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_financial_statement_analysis_response_status.py
+++ b/robosystems_client/models/operation_envelope_financial_statement_analysis_response_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class OperationEnvelopeFinancialStatementAnalysisResponseStatus(str, Enum):
+  COMPLETED = "completed"
+  FAILED = "failed"
+  PENDING = "pending"
+
+  def __str__(self) -> str:
+    return str(self.value)

--- a/robosystems_client/models/operation_envelope_view_response.py
+++ b/robosystems_client/models/operation_envelope_view_response.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.operation_envelope_view_response_status import (
+  OperationEnvelopeViewResponseStatus,
+)
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.view_response import ViewResponse
+
+
+T = TypeVar("T", bound="OperationEnvelopeViewResponse")
+
+
+@_attrs_define
+class OperationEnvelopeViewResponse:
+  """
+  Attributes:
+      operation (str): Kebab-case operation name
+      operation_id (str): op_-prefixed ULID for audit and SSE correlation
+      status (OperationEnvelopeViewResponseStatus): Operation lifecycle state
+      at (str): ISO-8601 UTC timestamp
+      result (None | Unset | ViewResponse): Command-specific result payload
+      created_by (None | str | Unset): User ID that initiated the operation (null for legacy callers)
+      idempotent_replay (bool | Unset): True when this envelope came from the idempotency cache — the underlying
+          command did not execute again. False on fresh executions. Default: False.
+  """
+
+  operation: str
+  operation_id: str
+  status: OperationEnvelopeViewResponseStatus
+  at: str
+  result: None | Unset | ViewResponse = UNSET
+  created_by: None | str | Unset = UNSET
+  idempotent_replay: bool | Unset = False
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    from ..models.view_response import ViewResponse
+
+    operation = self.operation
+
+    operation_id = self.operation_id
+
+    status = self.status.value
+
+    at = self.at
+
+    result: dict[str, Any] | None | Unset
+    if isinstance(self.result, Unset):
+      result = UNSET
+    elif isinstance(self.result, ViewResponse):
+      result = self.result.to_dict()
+    else:
+      result = self.result
+
+    created_by: None | str | Unset
+    if isinstance(self.created_by, Unset):
+      created_by = UNSET
+    else:
+      created_by = self.created_by
+
+    idempotent_replay = self.idempotent_replay
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "operation": operation,
+        "operationId": operation_id,
+        "status": status,
+        "at": at,
+      }
+    )
+    if result is not UNSET:
+      field_dict["result"] = result
+    if created_by is not UNSET:
+      field_dict["createdBy"] = created_by
+    if idempotent_replay is not UNSET:
+      field_dict["idempotentReplay"] = idempotent_replay
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.view_response import ViewResponse
+
+    d = dict(src_dict)
+    operation = d.pop("operation")
+
+    operation_id = d.pop("operationId")
+
+    status = OperationEnvelopeViewResponseStatus(d.pop("status"))
+
+    at = d.pop("at")
+
+    def _parse_result(data: object) -> None | Unset | ViewResponse:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        result_type_0 = ViewResponse.from_dict(data)
+
+        return result_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(None | Unset | ViewResponse, data)
+
+    result = _parse_result(d.pop("result", UNSET))
+
+    def _parse_created_by(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    created_by = _parse_created_by(d.pop("createdBy", UNSET))
+
+    idempotent_replay = d.pop("idempotentReplay", UNSET)
+
+    operation_envelope_view_response = cls(
+      operation=operation,
+      operation_id=operation_id,
+      status=status,
+      at=at,
+      result=result,
+      created_by=created_by,
+      idempotent_replay=idempotent_replay,
+    )
+
+    operation_envelope_view_response.additional_properties = d
+    return operation_envelope_view_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/operation_envelope_view_response_status.py
+++ b/robosystems_client/models/operation_envelope_view_response_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class OperationEnvelopeViewResponseStatus(str, Enum):
+  COMPLETED = "completed"
+  FAILED = "failed"
+  PENDING = "pending"
+
+  def __str__(self) -> str:
+    return str(self.value)

--- a/robosystems_client/models/resolved_report_info.py
+++ b/robosystems_client/models/resolved_report_info.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ResolvedReportInfo")
+
+
+@_attrs_define
+class ResolvedReportInfo:
+  """Information about the auto-resolved report.
+
+  Attributes:
+      report_id (str):
+      form (None | str | Unset):
+      filing_date (None | str | Unset):
+      fiscal_year (int | None | Unset):
+      fiscal_period (None | str | Unset):
+  """
+
+  report_id: str
+  form: None | str | Unset = UNSET
+  filing_date: None | str | Unset = UNSET
+  fiscal_year: int | None | Unset = UNSET
+  fiscal_period: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    report_id = self.report_id
+
+    form: None | str | Unset
+    if isinstance(self.form, Unset):
+      form = UNSET
+    else:
+      form = self.form
+
+    filing_date: None | str | Unset
+    if isinstance(self.filing_date, Unset):
+      filing_date = UNSET
+    else:
+      filing_date = self.filing_date
+
+    fiscal_year: int | None | Unset
+    if isinstance(self.fiscal_year, Unset):
+      fiscal_year = UNSET
+    else:
+      fiscal_year = self.fiscal_year
+
+    fiscal_period: None | str | Unset
+    if isinstance(self.fiscal_period, Unset):
+      fiscal_period = UNSET
+    else:
+      fiscal_period = self.fiscal_period
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "report_id": report_id,
+      }
+    )
+    if form is not UNSET:
+      field_dict["form"] = form
+    if filing_date is not UNSET:
+      field_dict["filing_date"] = filing_date
+    if fiscal_year is not UNSET:
+      field_dict["fiscal_year"] = fiscal_year
+    if fiscal_period is not UNSET:
+      field_dict["fiscal_period"] = fiscal_period
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    report_id = d.pop("report_id")
+
+    def _parse_form(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    form = _parse_form(d.pop("form", UNSET))
+
+    def _parse_filing_date(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    filing_date = _parse_filing_date(d.pop("filing_date", UNSET))
+
+    def _parse_fiscal_year(data: object) -> int | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(int | None | Unset, data)
+
+    fiscal_year = _parse_fiscal_year(d.pop("fiscal_year", UNSET))
+
+    def _parse_fiscal_period(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    fiscal_period = _parse_fiscal_period(d.pop("fiscal_period", UNSET))
+
+    resolved_report_info = cls(
+      report_id=report_id,
+      form=form,
+      filing_date=filing_date,
+      fiscal_year=fiscal_year,
+      fiscal_period=fiscal_period,
+    )
+
+    resolved_report_info.additional_properties = d
+    return resolved_report_info
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/view_metadata.py
+++ b/robosystems_client/models/view_metadata.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ViewMetadata")
+
+
+@_attrs_define
+class ViewMetadata:
+  """
+  Attributes:
+      view_id (str): Unique view identifier
+      facts_processed (int): Number of facts processed
+      construction_time_ms (float): Time to build view in milliseconds
+      source (str): Data source type
+      period_start (None | str | Unset): Period start date
+      period_end (None | str | Unset): Period end date
+  """
+
+  view_id: str
+  facts_processed: int
+  construction_time_ms: float
+  source: str
+  period_start: None | str | Unset = UNSET
+  period_end: None | str | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    view_id = self.view_id
+
+    facts_processed = self.facts_processed
+
+    construction_time_ms = self.construction_time_ms
+
+    source = self.source
+
+    period_start: None | str | Unset
+    if isinstance(self.period_start, Unset):
+      period_start = UNSET
+    else:
+      period_start = self.period_start
+
+    period_end: None | str | Unset
+    if isinstance(self.period_end, Unset):
+      period_end = UNSET
+    else:
+      period_end = self.period_end
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "view_id": view_id,
+        "facts_processed": facts_processed,
+        "construction_time_ms": construction_time_ms,
+        "source": source,
+      }
+    )
+    if period_start is not UNSET:
+      field_dict["period_start"] = period_start
+    if period_end is not UNSET:
+      field_dict["period_end"] = period_end
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    view_id = d.pop("view_id")
+
+    facts_processed = d.pop("facts_processed")
+
+    construction_time_ms = d.pop("construction_time_ms")
+
+    source = d.pop("source")
+
+    def _parse_period_start(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    period_start = _parse_period_start(d.pop("period_start", UNSET))
+
+    def _parse_period_end(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    period_end = _parse_period_end(d.pop("period_end", UNSET))
+
+    view_metadata = cls(
+      view_id=view_id,
+      facts_processed=facts_processed,
+      construction_time_ms=construction_time_ms,
+      source=source,
+      period_start=period_start,
+      period_end=period_end,
+    )
+
+    view_metadata.additional_properties = d
+    return view_metadata
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/view_response.py
+++ b/robosystems_client/models/view_response.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+  from ..models.view_metadata import ViewMetadata
+  from ..models.view_response_presentations import ViewResponsePresentations
+
+
+T = TypeVar("T", bound="ViewResponse")
+
+
+@_attrs_define
+class ViewResponse:
+  """
+  Attributes:
+      metadata (ViewMetadata):
+      presentations (ViewResponsePresentations): Presentation formats (pivot_table, narrative, etc.)
+  """
+
+  metadata: ViewMetadata
+  presentations: ViewResponsePresentations
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    metadata = self.metadata.to_dict()
+
+    presentations = self.presentations.to_dict()
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "metadata": metadata,
+        "presentations": presentations,
+      }
+    )
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.view_metadata import ViewMetadata
+    from ..models.view_response_presentations import ViewResponsePresentations
+
+    d = dict(src_dict)
+    metadata = ViewMetadata.from_dict(d.pop("metadata"))
+
+    presentations = ViewResponsePresentations.from_dict(d.pop("presentations"))
+
+    view_response = cls(
+      metadata=metadata,
+      presentations=presentations,
+    )
+
+    view_response.additional_properties = d
+    return view_response
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/view_response_presentations.py
+++ b/robosystems_client/models/view_response_presentations.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ViewResponsePresentations")
+
+
+@_attrs_define
+class ViewResponsePresentations:
+  """Presentation formats (pivot_table, narrative, etc.)"""
+
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    view_response_presentations = cls()
+
+    view_response_presentations.additional_properties = d
+    return view_response_presentations
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties


### PR DESCRIPTION
## Summary

Regen for [robosystems#956](https://github.com/RoboFinSystems/robosystems/pull/956) **plus the facade changes that make the new types reachable**. Parity with robosystems-typescript-client#164.

A regen alone would have left `financial_statement_analysis` and `build_fact_grid` returning `dict[str, Any]` over a now-typed envelope — the same erasure this client just fixed for `live_financial_statement` in #152, recreated the same day. The audit of this layer called this out explicitly while #956 was still unmerged, which is why both land together.

```python
live_financial_statement(…)     -> LiveFinancialStatementResponse
financial_statement_analysis(…) -> FinancialStatementAnalysisResponse   # was dict[str, Any]
build_fact_grid(…)              -> ViewResponse                          # was dict[str, Any]
```

Both new ones return through `_typed_result`, matching the rest of the typed-envelope methods in the class.

## Generated models added

`ViewResponse`, `ViewMetadata`, `FinancialStatementAnalysisResponse`, `AnalyticalStatementFactRow`, `ResolvedReportInfo`, and the two parameterised envelopes with their status enums.

## Verified the regen didn't undo the previous PR

The library query repair in #153 lives in hand-written GraphQL modules, which `generate-sdk` doesn't touch — confirmed zero remaining `statementContext` / `derivationRole` references after regenerating. Worth checking explicitly rather than assuming, since a regen that silently reverts a hand fix is precisely the failure mode we've been chasing.

## Regen source

Generated against a local backend on `main`. Note the container had to be restarted first — it had been running since before #956 merged and was still serving the old bare-`OperationEnvelope` schema. I verified the served spec contained the expected types before generating; regenerating against the stale process would have produced a clean-looking diff that omitted the change entirely.

## Testing

`just test-all` green — 439 passed / 17 skipped, ruff check, ruff format --check (842 files), basedpyright 0 errors / 0 warnings.

## Still outstanding

The `_typed_result` `{"deleted": True}` sentinel still fires for ~40 non-delete operations (`close_period` reproduces it while declaring `ClosePeriodResponse`). That's the highest-value remaining item from the audit and is contained — add a `sentinel_on_empty` flag, pass `True` at the eight delete sites. Existing tests only assert the sentinel on delete ops, so they pass unchanged.
