### PR TITLE
fix(client): scope the delete sentinel to actual delete operations

### DIFF
--- a/robosystems_client/clients/investor_client.py
+++ b/robosystems_client/clients/investor_client.py
@@ -145,19 +145,29 @@ class InvestorClient:
       raise RuntimeError(f"{label} failed: unexpected response shape: {envelope!r}")
     return envelope
 
-  def _typed_result(self, label: str, envelope: Any, expected: type[Any]) -> Any:
+  def _typed_result(
+    self,
+    label: str,
+    envelope: Any,
+    expected: type[Any],
+    *,
+    sentinel_on_empty: bool = False,
+  ) -> Any:
     """Return ``envelope.result`` for typed-envelope facade methods.
 
     See :meth:`LedgerClient._typed_result` for the contract. Briefly: in
     production the SDK gives back the typed attrs class; in tests using
-    dict mocks the result is a plain dict; ``None``/``Unset`` is
-    normalized to ``{"deleted": True}`` for delete-style returns.
+    dict mocks the result is a plain dict. ``None``/``Unset`` raises unless
+    ``sentinel_on_empty`` is set, which delete-style ops pass to preserve
+    their historical ``{"deleted": True}`` return.
     """
     result = envelope.result
     if result is None or (
       hasattr(result, "__class__") and "Unset" in result.__class__.__name__
     ):
-      return {"deleted": True}
+      if sentinel_on_empty:
+        return {"deleted": True}
+      raise RuntimeError(f"{label}: operation envelope had no result")
     return result
 
   # ── Portfolios ──────────────────────────────────────────────────────
@@ -226,7 +236,10 @@ class InvestorClient:
     )
     envelope = self._call_op("Delete portfolio block", response)
     return self._typed_result(
-      "Delete portfolio block", envelope, DeletePortfolioBlockResponse
+      "Delete portfolio block",
+      envelope,
+      DeletePortfolioBlockResponse,
+      sentinel_on_empty=True,
     )
 
   # ── Securities ──────────────────────────────────────────────────────
@@ -290,7 +303,9 @@ class InvestorClient:
       graph_id=graph_id, body=body, client=self._get_client()
     )
     envelope = self._call_op("Delete security", response)
-    return self._typed_result("Delete security", envelope, DeleteResult)
+    return self._typed_result(
+      "Delete security", envelope, DeleteResult, sentinel_on_empty=True
+    )
 
   # ── Positions (read-only — writes go through portfolio block) ────────
 

--- a/robosystems_client/clients/ledger_client.py
+++ b/robosystems_client/clients/ledger_client.py
@@ -458,7 +458,14 @@ class LedgerClient:
       raise RuntimeError(f"{label} failed: {envelope!r}")
     return envelope.result
 
-  def _typed_result(self, label: str, envelope: Any, expected: type[Any]) -> Any:
+  def _typed_result(
+    self,
+    label: str,
+    envelope: Any,
+    expected: type[Any],
+    *,
+    sentinel_on_empty: bool = False,
+  ) -> Any:
     """Return ``envelope.result`` for typed-envelope facade methods.
 
     The calling facade method's return-type annotation advertises the
@@ -482,9 +489,16 @@ class LedgerClient:
     if result is None or (
       hasattr(result, "__class__") and "Unset" in result.__class__.__name__
     ):
-      # Delete-style ops historically returned {"deleted": True} when the
-      # server omitted the result body. Preserve that sentinel for back-compat.
-      return {"deleted": True}
+      if sentinel_on_empty:
+        # Delete-style ops historically returned {"deleted": True} when the
+        # server omitted the result body. Preserve that sentinel for back-compat.
+        return {"deleted": True}
+      # Everything else advertises a real payload type. Returning the delete
+      # sentinel here handed callers a success-shaped dict that satisfies no
+      # field of the declared model — close_period reported {"deleted": True}
+      # while declaring ClosePeriodResponse. Raise instead, matching the
+      # TypeScript client's requireResult.
+      raise RuntimeError(f"{label}: operation envelope had no result")
     return result
 
   def _call_op(self, label: str, response: Any) -> Any:
@@ -806,7 +820,10 @@ class LedgerClient:
     )
     envelope = self._call_op("Delete taxonomy block", response)
     return self._typed_result(
-      "Delete taxonomy block", envelope, DeleteTaxonomyBlockResponse
+      "Delete taxonomy block",
+      envelope,
+      DeleteTaxonomyBlockResponse,
+      sentinel_on_empty=True,
     )
 
   def bind_text_block(
@@ -957,7 +974,9 @@ class LedgerClient:
       graph_id=graph_id, body=body, client=self._get_client()
     )
     envelope = self._call_op("Delete mapping association", response)
-    return self._typed_result("Delete mapping association", envelope, DeleteResult)
+    return self._typed_result(
+      "Delete mapping association", envelope, DeleteResult, sentinel_on_empty=True
+    )
 
   def auto_map_elements(self, graph_id: str, mapping_id: str) -> dict[str, Any]:
     """Trigger the AI MappingAgent (async). Returns an operation ack."""
@@ -1070,7 +1089,10 @@ class LedgerClient:
     )
     envelope = self._call_op("Delete information block", response)
     return self._typed_result(
-      "Delete information block", envelope, DeleteInformationBlockResponse
+      "Delete information block",
+      envelope,
+      DeleteInformationBlockResponse,
+      sentinel_on_empty=True,
     )
 
   # ── Schedules ──────────────────────────────────────────────────────
@@ -1224,7 +1246,10 @@ class LedgerClient:
     )
     envelope = self._call_op("Delete schedule", response)
     return self._typed_result(
-      "Delete schedule", envelope, DeleteInformationBlockResponse
+      "Delete schedule",
+      envelope,
+      DeleteInformationBlockResponse,
+      sentinel_on_empty=True,
     )
 
   def rebuild_schedule(
@@ -1398,7 +1423,9 @@ class LedgerClient:
       graph_id=graph_id, body=body, client=self._get_client()
     )
     envelope = self._call_op("Delete journal entry", response)
-    return self._typed_result("Delete journal entry", envelope, DeleteResult)
+    return self._typed_result(
+      "Delete journal entry", envelope, DeleteResult, sentinel_on_empty=True
+    )
 
   def reverse_journal_entry(
     self,
@@ -1829,7 +1856,9 @@ class LedgerClient:
     body = DeleteReportOperation(report_id=report_id)
     response = op_delete_report(graph_id=graph_id, body=body, client=self._get_client())
     envelope = self._call_op("Delete report", response)
-    return self._typed_result("Delete report", envelope, DeleteResult)
+    return self._typed_result(
+      "Delete report", envelope, DeleteResult, sentinel_on_empty=True
+    )
 
   def share_report(
     self, graph_id: str, report_id: str, publish_list_id: str
@@ -2023,7 +2052,9 @@ class LedgerClient:
       graph_id=graph_id, body=body, client=self._get_client()
     )
     envelope = self._call_op("Delete publish list", response)
-    return self._typed_result("Delete publish list", envelope, DeleteResult)
+    return self._typed_result(
+      "Delete publish list", envelope, DeleteResult, sentinel_on_empty=True
+    )
 
   def add_publish_list_members(
     self, graph_id: str, list_id: str, target_graph_ids: list[str]
@@ -2054,4 +2085,6 @@ class LedgerClient:
       graph_id=graph_id, body=body, client=self._get_client()
     )
     envelope = self._call_op("Remove publish list member", response)
-    return self._typed_result("Remove publish list member", envelope, DeleteResult)
+    return self._typed_result(
+      "Remove publish list member", envelope, DeleteResult, sentinel_on_empty=True
+    )


### PR DESCRIPTION
## Summary

`_typed_result` normalised a `None`/`Unset` envelope result to `{"deleted": True}` for **every** caller, not just deletes. The generated envelopes all declare `result: X | None | Unset = UNSET`, so that path is reachable on every operation — meaning an operation that produced nothing returned a **success-shaped dict satisfying no field of its declared model**.

Reproduced by the audit: `close_period` returned `{'deleted': True}` while declaring `ClosePeriodResponse`. The same applied to `create_journal_entry`, `create_report`, `evaluate_rules`, `create_closing_entry` and ~35 others — the accounting writes being the ones that matter.

The TypeScript client throws here (`requireResult`), so the two SDKs disagreed on what an empty envelope means for the same operation.

## Change

`_typed_result` now raises unless the caller opts in:

```python
if sentinel_on_empty:
    return {"deleted": True}   # documented back-compat for delete ops
raise RuntimeError(f"{label}: operation envelope had no result")
```

Ten genuine delete operations opt in; everything else raises.

## Classified by declared type, not method name

This is the part worth reviewing. `"Dispose schedule"` *reads* like a delete but returns `EventBlockEnvelope` — a real payload — so it raises like any other typed operation. A name-based sweep would have wrongly given it the sentinel.

Only call sites whose declared type is `DeleteResult`, `DeleteTaxonomyBlockResponse`, `DeleteInformationBlockResponse` or `DeletePortfolioBlockResponse` opt in — 9 in `LedgerClient`, 2 in `InvestorClient`, minus `Dispose schedule` = **10**.

## Verified both directions

```
_typed_result("Close period", empty_envelope, ...)
  → RuntimeError: Close period: operation envelope had no result
_typed_result("Delete report", empty_envelope, ..., sentinel_on_empty=True)
  → {'deleted': True}
```

`just test-all` green — 439 passed / 17 skipped, ruff, basedpyright 0 errors. Existing tests pass **unchanged**: they only ever assert the sentinel on delete operations, which is what made this safe to scope.

## Breaking, in the intended direction

An operation that returns an empty envelope now raises instead of silently returning a wrong dict. Any caller currently branching on `result.get("deleted")` from a non-delete op is reading a value that was never meaningful.

## Deliberately not fixed here

The sentinel is still **shape-invalid** for the three richer delete responses — `DeleteTaxonomyBlockResponse` requires `taxonomy_id` and `name`, which `{"deleted": True}` doesn't have. That's a real defect (audit M1), but fixing it changes behaviour for delete operations specifically and deserves its own PR rather than riding along with this one.
