### PR TITLE
Regenerate SDK: fact period windows + org-member repository subscribe

### DIFF
--- a/robosystems_client/api/subscriptions/create_repository_subscription.py
+++ b/robosystems_client/api/subscriptions/create_repository_subscription.py
@@ -114,7 +114,10 @@ def sync_detailed(
   """Create Repository Subscription
 
    For shared repositories only (sec, industry, etc.). User graph subscriptions are created
-  automatically during provisioning.
+  automatically during provisioning. Subscribes the caller by default; org owners and admins may
+  subscribe another member of their organization by passing `user_id`. Billing is charged to the
+  organization either way — repository access is per-user, so the subscriber determines who receives
+  access.
 
   Args:
       graph_id (str): Repository name (e.g., 'sec', 'industry')
@@ -149,7 +152,10 @@ def sync(
   """Create Repository Subscription
 
    For shared repositories only (sec, industry, etc.). User graph subscriptions are created
-  automatically during provisioning.
+  automatically during provisioning. Subscribes the caller by default; org owners and admins may
+  subscribe another member of their organization by passing `user_id`. Billing is charged to the
+  organization either way — repository access is per-user, so the subscriber determines who receives
+  access.
 
   Args:
       graph_id (str): Repository name (e.g., 'sec', 'industry')
@@ -179,7 +185,10 @@ async def asyncio_detailed(
   """Create Repository Subscription
 
    For shared repositories only (sec, industry, etc.). User graph subscriptions are created
-  automatically during provisioning.
+  automatically during provisioning. Subscribes the caller by default; org owners and admins may
+  subscribe another member of their organization by passing `user_id`. Billing is charged to the
+  organization either way — repository access is per-user, so the subscriber determines who receives
+  access.
 
   Args:
       graph_id (str): Repository name (e.g., 'sec', 'industry')
@@ -212,7 +221,10 @@ async def asyncio(
   """Create Repository Subscription
 
    For shared repositories only (sec, industry, etc.). User graph subscriptions are created
-  automatically during provisioning.
+  automatically during provisioning. Subscribes the caller by default; org owners and admins may
+  subscribe another member of their organization by passing `user_id`. Billing is charged to the
+  organization either way — repository access is per-user, so the subscriber determines who receives
+  access.
 
   Args:
       graph_id (str): Repository name (e.g., 'sec', 'industry')

--- a/robosystems_client/models/create_repository_subscription_request.py
+++ b/robosystems_client/models/create_repository_subscription_request.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="CreateRepositorySubscriptionRequest")
 
@@ -15,13 +17,23 @@ class CreateRepositorySubscriptionRequest:
 
   Attributes:
       plan_name (str): Plan name for the repository subscription
+      user_id (None | str | Unset): Subscribe this user instead of yourself. Org owners and admins only, and the
+          target must belong to the same organization. Omit to subscribe yourself. Repository access is per-user while
+          billing is org-level, so the subscriber is what determines who gets access.
   """
 
   plan_name: str
+  user_id: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
     plan_name = self.plan_name
+
+    user_id: None | str | Unset
+    if isinstance(self.user_id, Unset):
+      user_id = UNSET
+    else:
+      user_id = self.user_id
 
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
@@ -30,6 +42,8 @@ class CreateRepositorySubscriptionRequest:
         "plan_name": plan_name,
       }
     )
+    if user_id is not UNSET:
+      field_dict["user_id"] = user_id
 
     return field_dict
 
@@ -38,8 +52,18 @@ class CreateRepositorySubscriptionRequest:
     d = dict(src_dict)
     plan_name = d.pop("plan_name")
 
+    def _parse_user_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    user_id = _parse_user_id(d.pop("user_id", UNSET))
+
     create_repository_subscription_request = cls(
       plan_name=plan_name,
+      user_id=user_id,
     )
 
     create_repository_subscription_request.additional_properties = d

--- a/robosystems_client/models/fact_record.py
+++ b/robosystems_client/models/fact_record.py
@@ -17,7 +17,12 @@ class FactRecord:
   Attributes:
       element_id (str): Element qname (e.g., 'us-gaap:Assets')
       element_name (None | str | Unset): Element local name
+      period_start (None | str | Unset): Period start date (YYYY-MM-DD); null for instant facts. A duration fact is
+          identified by (start, end) — two facts for the same element can share an end date and differ only here (e.g. a
+          quarterly and a year-to-date figure from the same 10-Q).
       period_end (None | str | Unset): Period end date (YYYY-MM-DD)
+      duration_type (None | str | Unset): Period duration classification (e.g. 'quarterly', 'nine_months', 'annual');
+          null for instant facts. Use with period_start to tell overlapping windows apart.
       value (float | None | Unset): Numeric fact value
       unit (None | str | Unset): Unit of measure (e.g., 'USD')
       entity_ticker (None | str | Unset): Entity ticker; present only when an entity filter was applied
@@ -26,7 +31,9 @@ class FactRecord:
 
   element_id: str
   element_name: None | str | Unset = UNSET
+  period_start: None | str | Unset = UNSET
   period_end: None | str | Unset = UNSET
+  duration_type: None | str | Unset = UNSET
   value: float | None | Unset = UNSET
   unit: None | str | Unset = UNSET
   entity_ticker: None | str | Unset = UNSET
@@ -42,11 +49,23 @@ class FactRecord:
     else:
       element_name = self.element_name
 
+    period_start: None | str | Unset
+    if isinstance(self.period_start, Unset):
+      period_start = UNSET
+    else:
+      period_start = self.period_start
+
     period_end: None | str | Unset
     if isinstance(self.period_end, Unset):
       period_end = UNSET
     else:
       period_end = self.period_end
+
+    duration_type: None | str | Unset
+    if isinstance(self.duration_type, Unset):
+      duration_type = UNSET
+    else:
+      duration_type = self.duration_type
 
     value: float | None | Unset
     if isinstance(self.value, Unset):
@@ -81,8 +100,12 @@ class FactRecord:
     )
     if element_name is not UNSET:
       field_dict["element_name"] = element_name
+    if period_start is not UNSET:
+      field_dict["period_start"] = period_start
     if period_end is not UNSET:
       field_dict["period_end"] = period_end
+    if duration_type is not UNSET:
+      field_dict["duration_type"] = duration_type
     if value is not UNSET:
       field_dict["value"] = value
     if unit is not UNSET:
@@ -108,6 +131,15 @@ class FactRecord:
 
     element_name = _parse_element_name(d.pop("element_name", UNSET))
 
+    def _parse_period_start(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    period_start = _parse_period_start(d.pop("period_start", UNSET))
+
     def _parse_period_end(data: object) -> None | str | Unset:
       if data is None:
         return data
@@ -116,6 +148,15 @@ class FactRecord:
       return cast(None | str | Unset, data)
 
     period_end = _parse_period_end(d.pop("period_end", UNSET))
+
+    def _parse_duration_type(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    duration_type = _parse_duration_type(d.pop("duration_type", UNSET))
 
     def _parse_value(data: object) -> float | None | Unset:
       if data is None:
@@ -156,7 +197,9 @@ class FactRecord:
     fact_record = cls(
       element_id=element_id,
       element_name=element_name,
+      period_start=period_start,
       period_end=period_end,
+      duration_type=duration_type,
       value=value,
       unit=unit,
       entity_ticker=entity_ticker,

--- a/robosystems_client/models/view_response.py
+++ b/robosystems_client/models/view_response.py
@@ -33,6 +33,8 @@ class ViewResponse:
           facts (list[FactRecord] | Unset): Deduplicated fact records
           summary (None | Unset | ViewResponseSummaryType0): Per-element aggregates, only when include_summary=true. Note
               that `total` sums across every returned period, which is meaningful for duration facts and not for instants.
+              Overlapping duration windows sharing a period_end (quarter + year-to-date) contribute only the narrowest window,
+              so a quarter is never double-counted inside its own YTD figure.
   """
 
   metadata: ViewMetadata


### PR DESCRIPTION
## Summary

Regenerated from the current API spec (robosystems main, post-#1048). Three API changes reach the client:

- **`FactRecord` gains `period_start` and `duration_type`** — a duration fact is identified by (start, end), so two facts for the same element can share an end date (quarterly + year-to-date from the same 10-Q). Callers can now tell overlapping windows apart; previously the disambiguation shipped server-side (#1039) but stopped at the DTO.
- **`CreateRepositorySubscriptionRequest` gains optional `user_id`** — org owners/admins can subscribe another member of the same org to a repository (billing stays org-level, access is per-user).
- **`ViewResponse.summary` docs** now state the narrowest-window aggregation rule (a quarter is never double-counted inside its own YTD figure).

GraphQL SDL snapshot verified current (no drift).

## Testing

`just test-all` green — 490 passed, ruff + format + basedpyright clean.

No version bump — that happens at publish.