### PR TITLE
Release workflow: curated notes support and input-handling hardening

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -255,6 +255,8 @@ uv publish
 
 **Note:** Only maintainers can publish new versions.
 
+**Release notes:** `tag-release.yml` auto-generates the changelog from changes since the last tag (via the Claude API). For milestone releases, commit curated notes to `.github/release-notes/v<version>.md` _before_ dispatching `create-release.yml` — when that file exists at the tagged ref it replaces the generated changelog (and the release statistics section is skipped).
+
 ## Security
 
 ### Security Vulnerabilities

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -50,13 +50,15 @@ jobs:
 
       - name: Check If Tag Exists
         id: check-tag
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          if [ $(git tag -l "v${{ steps.get-version.outputs.version }}") ]; then
+          if [ -n "$(git tag -l "v$VERSION")" ]; then
             echo "tag_exists=true" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get-version.outputs.version }} already exists"
+            echo "Tag v$VERSION already exists"
           else
             echo "tag_exists=false" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get-version.outputs.version }} does not exist yet"
+            echo "Tag v$VERSION does not exist yet"
           fi
 
       - name: Check for curated release notes
@@ -81,11 +83,14 @@ jobs:
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-
-          # Get the last release tag
-          LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          # Get the last release tag. The pattern is anchored at both ends so
+          # only strict vMAJOR.MINOR.PATCH tags are eligible — a tag that
+          # merely starts with a version (a suffixed or decorated ref) is not
+          # a release and must never be picked as the diff base.
+          LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
           if [ -z "$LAST_TAG" ]; then
             echo "No previous release found, analyzing all commits"
@@ -199,13 +204,16 @@ jobs:
       - name: Call Claude API for changelog
         if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: claude-changelog
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
         run: |
           # Call Claude API with the analysis prompt
           PROMPT=$(cat /tmp/changelog_prompt.txt)
 
           # Create a proper JSON payload using jq to handle escaping
           PAYLOAD=$(jq -n \
-            --arg model "${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}" \
+            --arg model "$CLAUDE_MODEL" \
             --arg content "$PROMPT" \
             '{
               "model": $model,
@@ -218,11 +226,16 @@ jobs:
               ]
             }')
 
-          RESPONSE=$(curl -s --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.ANTHROPIC_API_KEY }}" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "$PAYLOAD")
+          # The API key is fed to curl over stdin as a config file rather than
+          # as an -H argument. A shell variable in an -H flag is expanded
+          # before exec, so the literal credential would still land in the
+          # curl process's argv, where it is readable by any other process on
+          # the runner; --config keeps it off the command line entirely.
+          RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" \
+            | curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
+              -H "Content-Type: application/json" \
+              -H "anthropic-version: 2023-06-01" \
+              -d "$PAYLOAD")
 
           # Check for API errors
           if echo "$RESPONSE" | jq -e '.error' > /dev/null; then
@@ -303,11 +316,13 @@ jobs:
 
       - name: Create Release Tag
         if: steps.check-tag.outputs.tag_exists == 'false'
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.get-version.outputs.version }}" -m "Release v${{ steps.get-version.outputs.version }}"
-          git push origin "v${{ steps.get-version.outputs.version }}"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
 
       - name: Create GitHub Release
         if: steps.check-tag.outputs.tag_exists == 'false'
@@ -327,10 +342,13 @@ jobs:
         if: steps.check-tag.outputs.tag_exists == 'false'
         # SECURITY (H2): the changelog (generated or curated) is untrusted;
         # it is read from the file written by the compose step rather than
-        # interpolated with ${{ ... }} into the shell.
+        # interpolated with ${{ ... }} into the shell. The version and the
+        # previous tag are likewise passed via env — both originate outside
+        # this workflow (pyproject.toml and the git tag list).
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-
           echo "## 🚀 Release v$VERSION Created" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Release URL:** [v$VERSION](https://github.com/RoboFinSystems/robosystems-python-client/releases/tag/v$VERSION)" >> $GITHUB_STEP_SUMMARY
@@ -340,7 +358,7 @@ jobs:
           echo "- **Files Changed:** ${{ steps.analyze-changes.outputs.files_changed }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Lines Added:** ${{ steps.analyze-changes.outputs.additions }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous Release:** $LAST_TAG" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📝 Changelog" >> $GITHUB_STEP_SUMMARY
           cat /tmp/release_changelog.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -141,10 +141,23 @@ jobs:
       - name: Generate changelog with Claude
         if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: generate-changelog
+        # SECURITY (H2): pass all git-derived, attacker-influenceable values
+        # (commit messages, changed filenames, PR refs) via env instead of
+        # splicing them into the script with ${{ ... }}. The heredoc expands
+        # $VAR from the environment but never re-evaluates command
+        # substitutions contained in an expansion result, so a commit message
+        # or filename like $(...) or `...` cannot execute.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
+          FILES_CHANGED: ${{ steps.analyze-changes.outputs.files_changed }}
+          COMMITS_COUNT: ${{ steps.analyze-changes.outputs.commits_count }}
+          ADDITIONS: ${{ steps.analyze-changes.outputs.additions }}
+          DELETIONS: ${{ steps.analyze-changes.outputs.deletions }}
+          COMMIT_MESSAGES: ${{ steps.analyze-changes.outputs.commit_messages }}
+          DETAILED_CHANGES: ${{ steps.analyze-changes.outputs.detailed_changes }}
+          PR_REFS: ${{ steps.analyze-changes.outputs.pr_refs }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-          LAST_TAG="${{ steps.analyze-changes.outputs.last_tag }}"
-
           # Create analysis prompt for Claude
           cat > /tmp/changelog_prompt.txt << PROMPT_EOF
           I need you to generate a concise but informative changelog for a software release.
@@ -152,19 +165,19 @@ jobs:
           **Release Info:**
           - Version: $VERSION
           - Previous Version: $LAST_TAG
-          - Files Changed: ${{ steps.analyze-changes.outputs.files_changed }}
-          - Commits: ${{ steps.analyze-changes.outputs.commits_count }}
-          - Lines Added: ${{ steps.analyze-changes.outputs.additions }}
-          - Lines Deleted: ${{ steps.analyze-changes.outputs.deletions }}
+          - Files Changed: $FILES_CHANGED
+          - Commits: $COMMITS_COUNT
+          - Lines Added: $ADDITIONS
+          - Lines Deleted: $DELETIONS
 
           **Recent Commits:**
-          ${{ steps.analyze-changes.outputs.commit_messages }}
+          $COMMIT_MESSAGES
 
           **File Changes:**
-          ${{ steps.analyze-changes.outputs.detailed_changes }}
+          $DETAILED_CHANGES
 
           **PR References:**
-          ${{ steps.analyze-changes.outputs.pr_refs }}
+          $PR_REFS
 
           Please generate a changelog that includes:
           1. A brief 1-2 sentence summary of this release

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          if [ -n "$(git tag -l "v$VERSION")" ]; then
+          if [ -n "$(git tag -l "v${VERSION}")" ]; then
             echo "tag_exists=true" >> $GITHUB_OUTPUT
             echo "Tag v$VERSION already exists"
           else
@@ -83,13 +83,10 @@ jobs:
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
-        env:
-          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          # Get the last release tag. The pattern is anchored at both ends so
-          # only strict vMAJOR.MINOR.PATCH tags are eligible — a tag that
-          # merely starts with a version (a suffixed or decorated ref) is not
-          # a release and must never be picked as the diff base.
+          # Get the last release tag. The pattern is anchored at both ends so only
+          # a strict vMAJOR.MINOR.PATCH tag can be selected: LAST_TAG flows into
+          # later git commands and prompt text, so it must not carry trailing text.
           LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
           if [ -z "$LAST_TAG" ]; then
@@ -226,11 +223,13 @@ jobs:
               ]
             }')
 
-          # The API key is fed to curl over stdin as a config file rather than
-          # as an -H argument. A shell variable in an -H flag is expanded
-          # before exec, so the literal credential would still land in the
-          # curl process's argv, where it is readable by any other process on
-          # the runner; --config keeps it off the command line entirely.
+            # The credential is fed to curl through a config file on stdin rather
+            # than an -H flag. Writing -H "x-api-key: $ANTHROPIC_API_KEY" would not
+            # help: the shell expands the variable before exec, so the literal key
+            # still lands in the curl process argv, which any other process on the
+            # runner can read. printf is a bash builtin, so it adds no process of
+            # its own, and curl parses the config at startup so --retry resends the
+            # header correctly.
           RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" \
             | curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
               -H "Content-Type: application/json" \
@@ -358,7 +357,7 @@ jobs:
           echo "- **Files Changed:** ${{ steps.analyze-changes.outputs.files_changed }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Lines Added:** ${{ steps.analyze-changes.outputs.additions }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Previous Release:** $LAST_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous Release:** ${LAST_TAG}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📝 Changelog" >> $GITHUB_STEP_SUMMARY
           cat /tmp/release_changelog.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -59,6 +59,25 @@ jobs:
             echo "Tag v${{ steps.get-version.outputs.version }} does not exist yet"
           fi
 
+      - name: Check for curated release notes
+        if: steps.check-tag.outputs.tag_exists == 'false'
+        id: curated-notes
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          # Milestone releases ship hand-written notes committed at
+          # .github/release-notes/v<version>.md; when present they replace
+          # the generated delta changelog below.
+          NOTES_FILE=".github/release-notes/v${VERSION}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "path=$NOTES_FILE" >> $GITHUB_OUTPUT
+            echo "📝 Curated release notes found: $NOTES_FILE"
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "No curated notes at $NOTES_FILE — generating changelog from changes since last tag"
+          fi
+
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
@@ -120,7 +139,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Generate changelog with Claude
-        if: steps.check-tag.outputs.tag_exists == 'false'
+        if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: generate-changelog
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
@@ -165,7 +184,7 @@ jobs:
           echo "✅ Changelog prompt created"
 
       - name: Call Claude API for changelog
-        if: steps.check-tag.outputs.tag_exists == 'false'
+        if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: claude-changelog
         run: |
           # Call Claude API with the analysis prompt
@@ -217,6 +236,58 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
+      - name: Compose release body
+        if: steps.check-tag.outputs.tag_exists == 'false'
+        # SECURITY (H2): changelog content (generated or curated) is untrusted
+        # relative to the shell — emit it via printf/cat from env and files,
+        # never by splicing ${{ ... }} into the script.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          CURATED_FOUND: ${{ steps.curated-notes.outputs.found }}
+          CURATED_PATH: ${{ steps.curated-notes.outputs.path }}
+          CHANGELOG: ${{ steps.claude-changelog.outputs.changelog }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
+          COMMITS_COUNT: ${{ steps.analyze-changes.outputs.commits_count }}
+          FILES_CHANGED: ${{ steps.analyze-changes.outputs.files_changed }}
+          ADDITIONS: ${{ steps.analyze-changes.outputs.additions }}
+          DELETIONS: ${{ steps.analyze-changes.outputs.deletions }}
+        run: |
+          if [ "$CURATED_FOUND" = "true" ]; then
+            cp "$CURATED_PATH" /tmp/release_changelog.md
+          else
+            printf '%s\n' "$CHANGELOG" > /tmp/release_changelog.md
+          fi
+
+          {
+            echo "# RoboSystems Python SDK v${VERSION}"
+            echo ""
+            cat /tmp/release_changelog.md
+            echo ""
+            echo "---"
+            echo ""
+            if [ "$CURATED_FOUND" != "true" ]; then
+              echo "## 📊 Release Statistics"
+              echo ""
+              echo "- **Commits:** ${COMMITS_COUNT}"
+              echo "- **Files Changed:** ${FILES_CHANGED}"
+              echo "- **Lines Added:** ${ADDITIONS}"
+              echo "- **Lines Deleted:** ${DELETIONS}"
+              echo "- **Previous Release:** ${LAST_TAG}"
+              echo ""
+            fi
+            echo "## 🔗 Links"
+            echo ""
+            echo "- **Full Changelog:** [${LAST_TAG}...v${VERSION}](https://github.com/RoboFinSystems/robosystems-python-client/compare/${LAST_TAG}...v${VERSION})"
+            echo "- **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems-python-client/releases)"
+            if [ "$CURATED_FOUND" != "true" ]; then
+              echo ""
+              echo "---"
+              echo "🤖 Generated with [Claude Code](https://claude.ai/code)"
+            fi
+          } > /tmp/release_body.md
+
+          echo "✅ Release body composed ($([ "$CURATED_FOUND" = "true" ] && echo "curated notes" || echo "generated changelog"))"
+
       - name: Create Release Tag
         if: steps.check-tag.outputs.tag_exists == 'false'
         run: |
@@ -232,28 +303,7 @@ jobs:
         with:
           tag_name: v${{ steps.get-version.outputs.version }}
           name: Release v${{ steps.get-version.outputs.version }}
-          body: |
-            # RoboSystems Python SDK v${{ steps.get-version.outputs.version }}
-
-            ${{ steps.claude-changelog.outputs.changelog }}
-
-            ---
-
-            ## 📊 Release Statistics
-
-            - **Commits:** ${{ steps.analyze-changes.outputs.commits_count }}
-            - **Files Changed:** ${{ steps.analyze-changes.outputs.files_changed }}
-            - **Lines Added:** ${{ steps.analyze-changes.outputs.additions }}
-            - **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}
-            - **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}
-
-            ## 🔗 Links
-
-            - **Full Changelog:** [${{ steps.analyze-changes.outputs.last_tag }}...v${{ steps.get-version.outputs.version }}](https://github.com/RoboFinSystems/robosystems-python-client/compare/${{ steps.analyze-changes.outputs.last_tag }}...v${{ steps.get-version.outputs.version }})
-            - **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems-python-client/releases)
-
-            ---
-            🤖 Generated with [Claude Code](https://claude.ai/code)
+          body_path: /tmp/release_body.md
           draft: false
           prerelease: false
         env:
@@ -262,6 +312,9 @@ jobs:
 
       - name: Create release summary
         if: steps.check-tag.outputs.tag_exists == 'false'
+        # SECURITY (H2): the changelog (generated or curated) is untrusted;
+        # it is read from the file written by the compose step rather than
+        # interpolated with ${{ ... }} into the shell.
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
 
@@ -276,5 +329,5 @@ jobs:
           echo "- **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🤖 Claude-Generated Changelog" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.claude-changelog.outputs.changelog }}" >> $GITHUB_STEP_SUMMARY
+          echo "### 📝 Changelog" >> $GITHUB_STEP_SUMMARY
+          cat /tmp/release_changelog.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

`tag-release.yml` normally builds the GitHub release body from a Claude-generated changelog of `git diff <last-tag>..HEAD`. That is the right default for routine SDK regeneration releases, but a milestone release deserves hand-written notes.

This adds an opt-in path: if `.github/release-notes/v<version>.md` exists at the tagged ref, that file becomes the release body verbatim.

## Mechanism

1. New step **Check for curated release notes** (`id: curated-notes`) runs right after the tag-exists check and sets `found` / `path` outputs.
2. **Generate changelog with Claude** and **Call Claude API for changelog** gain `&& steps.curated-notes.outputs.found != 'true'`, so the API is not called at all when curated notes are present.
3. New step **Compose release body** writes `/tmp/release_changelog.md` (curated file or generated changelog) and `/tmp/release_body.md`, conditionally including the Release Statistics block and the "Generated with Claude Code" footer.
4. **Create GitHub Release** switches from an inline `body: |` template to `body_path: /tmp/release_body.md`, and the step summary now `cat`s the changelog file instead of interpolating the changelog output into the shell.

With curated notes the body is: title header, the curated content, then the Links section — no statistics, no generated-with footer.

## Default path is unchanged

The composed body was diffed against the previous inline template rendered from the same values: **byte-for-byte identical** when no curated file exists. No behavior change for routine releases.

## Leftover files can't leak

The filename is version-specific (`v<version>.md`, matched against the version read from `pyproject.toml`). A file committed for one release is simply never matched by a later one, so a forgotten file cannot silently become the next release's notes.

## Security

Changelog content — generated or curated — is untrusted relative to the shell, so it moves through env vars and `printf`/`cat` from files rather than being spliced into a script with `${{ ... }}`, following the existing `# SECURITY (H2)` discipline. Switching to `body_path` also removes the previous inline `${{ steps.claude-changelog.outputs.changelog }}` interpolation.

## Test plan

- `yamllint` clean apart from the file's pre-existing line-length/document-start style warnings; workflow parses and all step `if:` conditions and step ids resolve as expected.
- Compose step executed locally in both modes with a representative multi-line changelog (including shell metacharacters, which render literally):
  - no curated file → output diffed against the old inline template: identical.
  - curated file present → curated content verbatim, statistics block and footer omitted, links section retained.
- Next routine release exercises the default path end to end; the curated path is exercised the first time notes are committed for a version.

Aligns this repo with roboledger-app PR #280.


Also hardens input handling in the changelog step (values now passed via `env:`).


Follow-up commit extends the same `env:` discipline to the remaining steps, tightens the release-tag match, and hardens credential handling in the API call.
