### PR TITLE
Pre-1.0 alignment: library facade wiring, lazy clients, auth header routing, TS parity

### DIFF
--- a/robosystems_client/__init__.py
+++ b/robosystems_client/__init__.py
@@ -1,6 +1,15 @@
 """RoboSystems Python Client."""
 
 from .client import AuthenticatedClient, Client
+from .clients import (
+  InvestorClient,
+  LedgerClient,
+  LibraryClient,
+  RoboSystemsClientConfig,
+  RoboSystemsClients,
+  get_clients,
+)
+from .graphql.client import GraphQLError
 
 # Convenience aliases for the main SDK
 RoboSystemsClient = AuthenticatedClient
@@ -9,8 +18,15 @@ RoboSystemsSDK = AuthenticatedClient
 __all__ = (
   "AuthenticatedClient",
   "Client",
+  "GraphQLError",
+  "InvestorClient",
+  "LedgerClient",
+  "LibraryClient",
   "RoboSystemsClient",
+  "RoboSystemsClientConfig",
+  "RoboSystemsClients",
   "RoboSystemsSDK",
+  "get_clients",
 )
 
 

--- a/robosystems_client/clients/__init__.py
+++ b/robosystems_client/clients/__init__.py
@@ -78,6 +78,7 @@ from .auth_integration import (
 
 # JWT Token utilities
 from .token_utils import (
+  TokenProvider,
   validate_jwt_format,
   extract_jwt_from_header,
   decode_jwt_payload,
@@ -123,6 +124,7 @@ __all__ = [
   "RoboSystemsClients",
   "RoboSystemsClientConfig",
   "AsyncRoboSystemsClients",
+  "get_clients",
   # SSE Client
   "SSEClient",
   "EventType",
@@ -200,40 +202,59 @@ __all__ = [
   "extract_token_from_cookie",
   "find_valid_token",
   "TokenManager",
+  "TokenProvider",
   "TokenSource",
   # DataFrame utilities (optional)
   "HAS_PANDAS",
   "DataFrameQueryClient",
 ]
 
-# Create a default clients instance
-clients = RoboSystemsClients()
+# Lazy default clients instance. Constructed on first use, never at
+# import time — an import-time singleton would bind the default
+# localhost:8000 base URL (and an empty token) before the caller has a
+# chance to configure anything. Mirrors the TypeScript client's
+# `getClients()`.
+_clients: RoboSystemsClients | None = None
+
+
+def get_clients() -> RoboSystemsClients:
+  """Return the shared default :class:`RoboSystemsClients` instance.
+
+  Created lazily on first call with default configuration
+  (``base_url="http://localhost:8000"``, no token). For configured
+  instances, construct :class:`RoboSystemsClients` (or one of the
+  ``auth_integration`` helpers) directly.
+  """
+  global _clients
+  if _clients is None:
+    _clients = RoboSystemsClients()
+  return _clients
 
 
 # Export convenience functions
 def monitor_operation(operation_id: str, on_progress=None):
   """Monitor an operation using the default clients instance"""
-  return clients.monitor_operation(operation_id, on_progress)
+  return get_clients().monitor_operation(operation_id, on_progress)
 
 
 def execute_query(graph_id: str, query: str, parameters=None):
   """Execute a query using the default clients instance"""
-  return clients.query.query(graph_id, query, parameters)
+  return get_clients().query.query(graph_id, query, parameters)
 
 
 def stream_query(graph_id: str, query: str, parameters=None, chunk_size=None):
   """Stream a query using the default clients instance"""
-  return clients.query.stream_query(graph_id, query, parameters, chunk_size)
+  return get_clients().query.stream_query(graph_id, query, parameters, chunk_size)
 
 
 def operator_query(graph_id: str, message: str, context=None):
   """Execute an operator query using the default clients instance"""
-  return clients.operator.query(graph_id, message, context)
+  return get_clients().operator.query(graph_id, message, context)
 
 
 def analyze_financials(graph_id: str, message: str, on_progress=None):
   """Execute financial operator using the default clients instance"""
-  return clients.operator.analyze_financials(graph_id, message, on_progress)
+  return get_clients().operator.analyze_financials(graph_id, message, on_progress)
 
 
 # DataFrame convenience functions (if pandas is available)

--- a/robosystems_client/clients/auth_integration.py
+++ b/robosystems_client/clients/auth_integration.py
@@ -8,6 +8,43 @@ from ..client import Client, AuthenticatedClient
 from .facade import RoboSystemsClients, RoboSystemsClientConfig
 
 
+def _apply_auth_header(headers: Dict[str, str], credential: str) -> None:
+  """Set the correct auth header for a credential, routed by shape.
+
+  The backend accepts two credential formats, and they go in DIFFERENT
+  headers — not interchangeable (see ``graphql/client.py``):
+
+  - Long-lived API keys (``rfs…`` prefix) → ``X-API-Key``. Validated
+    against the api_keys table.
+  - Short-lived JWTs → ``Authorization: Bearer …``. Validated by the
+    JWT middleware.
+
+  Sending a JWT as ``X-API-Key`` (or an API key as Bearer) both fail
+  with 401 "Invalid API key" — so exactly one header is set, never both.
+  """
+  if credential.startswith("rfs"):
+    headers["X-API-Key"] = credential
+  else:
+    headers["Authorization"] = f"Bearer {credential}"
+
+
+def _build_sdk_client(base_url: str, credential: str, headers: Dict[str, str]):
+  """Build an :class:`AuthenticatedClient` with prefix-routed auth.
+
+  Mirrors ``_apply_auth_header``: ``rfs…`` keys ride in ``X-API-Key``
+  (no prefix); anything else rides in ``Authorization: Bearer …``.
+  """
+  if credential.startswith("rfs"):
+    return AuthenticatedClient(
+      base_url=base_url,
+      token=credential,
+      prefix="",
+      auth_header_name="X-API-Key",
+      headers=headers,
+    )
+  return AuthenticatedClient(base_url=base_url, token=credential, headers=headers)
+
+
 class AuthenticatedClients(RoboSystemsClients):
   """Extensions with proper authentication integration"""
 
@@ -30,11 +67,12 @@ class AuthenticatedClients(RoboSystemsClients):
     elif not config.base_url:
       config.base_url = "https://api.robosystems.ai"
 
-    # Add authentication headers
+    # Add the authentication header, routed by credential shape —
+    # rfs… API keys go in X-API-Key, JWTs in Authorization: Bearer.
+    # Never both: the copy in the wrong header is guaranteed-invalid.
     if not config.headers:
       config.headers = {}
-    config.headers["X-API-Key"] = api_key
-    config.headers["Authorization"] = f"Bearer {api_key}"
+    _apply_auth_header(config.headers, api_key)
 
     # Store the token for later use by child clients
     self._token = api_key
@@ -42,8 +80,8 @@ class AuthenticatedClients(RoboSystemsClients):
     super().__init__(config)
 
     # Store authenticated client for SDK operations
-    self._authenticated_client = AuthenticatedClient(
-      base_url=config.base_url, token=api_key, headers=config.headers
+    self._authenticated_client = _build_sdk_client(
+      config.base_url, api_key, config.headers
     )
 
   @property
@@ -142,10 +180,13 @@ class TokenClients(RoboSystemsClients):
     elif not config.base_url:
       config.base_url = "https://api.robosystems.ai"
 
-    # Add authentication headers
+    # Add the authentication header, routed by credential shape.
+    # JWTs (the expected input here) ride in Authorization: Bearer;
+    # if a caller hands this class an rfs… API key anyway, route it
+    # to X-API-Key instead of sending a guaranteed-invalid Bearer.
     if not config.headers:
       config.headers = {}
-    config.headers["Authorization"] = f"Bearer {token}"
+    _apply_auth_header(config.headers, token)
 
     # Store the token for later use by child clients
     self._token = token
@@ -153,8 +194,8 @@ class TokenClients(RoboSystemsClients):
     super().__init__(config)
 
     # Store authenticated client
-    self._authenticated_client = AuthenticatedClient(
-      base_url=config.base_url, token=token, headers=config.headers
+    self._authenticated_client = _build_sdk_client(
+      config.base_url, token, config.headers
     )
 
   @property

--- a/robosystems_client/clients/facade.py
+++ b/robosystems_client/clients/facade.py
@@ -15,6 +15,7 @@ from .table_client import TableClient
 from .graph_client import GraphClient
 from .investor_client import InvestorClient
 from .ledger_client import LedgerClient
+from .library_client import LibraryClient
 from .sse_client import SSEClient
 
 
@@ -28,6 +29,13 @@ class RoboSystemsClientConfig:
   retry_delay: int = 1000
   timeout: int = 30
   s3_endpoint_url: Optional[str] = None  # Override S3 endpoint (e.g., for LocalStack)
+  # Zero-arg callable returning the current auth credential, consulted
+  # on every request by the GraphQL-backed facades (ledger / investor /
+  # library). Wins over the static token when set — use it when the
+  # credential rotates (short-lived JWTs), so refreshes are picked up
+  # without rebuilding the clients. Mirrors the TypeScript client's
+  # `tokenProvider`. See `token_utils.TokenProvider`.
+  token_provider: Optional[Callable[[], Optional[str]]] = None
 
 
 class RoboSystemsClients:
@@ -45,6 +53,7 @@ class RoboSystemsClients:
       "retry_delay": config.retry_delay,
       "timeout": config.timeout,
       "s3_endpoint_url": config.s3_endpoint_url,
+      "token_provider": config.token_provider,
     }
 
     # Extract token from headers if it was set by auth classes
@@ -73,6 +82,10 @@ class RoboSystemsClients:
     self.graphs = GraphClient(self.config)
     self.ledger = LedgerClient(self.config)
     self.investor = InvestorClient(self.config)
+    # Library reads accept graph_id per-call — pass either the
+    # "library" sentinel (canonical) or any tenant graph_id (tenant
+    # library copy + CoA).
+    self.library = LibraryClient(self.config)
     self.reports = self.ledger  # backward compat alias
 
   def monitor_operation(

--- a/robosystems_client/clients/investor_client.py
+++ b/robosystems_client/clients/investor_client.py
@@ -42,6 +42,7 @@ from ..api.extensions_robo_investor.update_security import (
 )
 from ..client import AuthenticatedClient
 from ..graphql.client import GraphQLClient, strip_none_vars
+from .token_utils import resolve_config_token
 from ..graphql.generated.get_investor_holdings import (
   GetInvestorHoldings,
 )
@@ -116,22 +117,26 @@ class InvestorClient:
     self.timeout = config.get("timeout", 60)
 
   def _get_client(self) -> AuthenticatedClient:
-    if not self.token:
+    # Resolved per call: a configured `token_provider` wins over the
+    # static token, so rotating credentials are picked up per-request.
+    token = resolve_config_token(self.config)
+    if not token:
       raise RuntimeError("No API key provided. Set X-API-Key in headers.")
     return AuthenticatedClient(
       base_url=self.base_url,
-      token=self.token,
+      token=token,
       prefix="",
       auth_header_name="X-API-Key",
       headers=self.headers,
     )
 
   def _get_graphql_client(self) -> GraphQLClient:
-    if not self.token:
+    token = resolve_config_token(self.config)
+    if not token:
       raise RuntimeError("No API key provided. Set X-API-Key in headers.")
     return GraphQLClient(
       base_url=self.base_url,
-      token=self.token,
+      token=token,
       headers=self.headers,
       timeout=self.timeout,
     )

--- a/robosystems_client/clients/ledger_client.py
+++ b/robosystems_client/clients/ledger_client.py
@@ -40,6 +40,9 @@ from ..api.extensions_robo_ledger.build_fact_grid import (
 from ..api.extensions_robo_ledger.close_period import (
   sync_detailed as op_close_period,
 )
+from ..api.extensions_robo_ledger.compute_metrics import (
+  sync_detailed as op_compute_metrics,
+)
 from ..api.extensions_robo_ledger.create_agent import (
   sync_detailed as op_create_agent,
 )
@@ -156,6 +159,7 @@ from ..api.extensions_robo_ledger.update_journal_entry import (
 )
 from ..client import AuthenticatedClient
 from ..graphql.client import GraphQLClient, strip_none_vars
+from .token_utils import resolve_config_token
 from ..graphql.generated.get_information_block import (
   GetInformationBlock,
 )
@@ -345,6 +349,10 @@ from ..graphql.generated.list_ledger_unmapped_elements import (
   ListLedgerUnmappedElements,
   ListLedgerUnmappedElementsUnmappedElements,
 )
+from ..graphql.generated.mapping_candidates import (
+  MappingCandidates,
+  MappingCandidatesMappingCandidates,
+)
 from ..graphql.generated.operations import (
   GET_INFORMATION_BLOCK_GQL,
   GET_LEDGER_ACCOUNT_ROLLUPS_GQL,
@@ -381,6 +389,7 @@ from ..graphql.generated.operations import (
   LIST_LEDGER_TAXONOMIES_GQL,
   LIST_LEDGER_TRANSACTIONS_GQL,
   LIST_LEDGER_UNMAPPED_ELEMENTS_GQL,
+  MAPPING_CANDIDATES_GQL,
 )
 from ..models.add_publish_list_members_operation import AddPublishListMembersOperation
 from ..models.auto_map_elements_operation import AutoMapElementsOperation
@@ -423,6 +432,8 @@ from ..models.update_journal_entry_request import UpdateJournalEntryRequest
 from ..models.update_schedule_arm import UpdateScheduleArm
 from ..models.update_schedule_request import UpdateScheduleRequest
 from ..models.close_period_operation import ClosePeriodOperation
+from ..models.compute_metrics_request import ComputeMetricsRequest
+from ..models.compute_metrics_response import ComputeMetricsResponse
 from ..models.create_view_request import CreateViewRequest
 from ..models.create_mapping_association_operation import (
   CreateMappingAssociationOperation,
@@ -547,11 +558,14 @@ class LedgerClient:
     self.timeout = config.get("timeout", 60)
 
   def _get_client(self) -> AuthenticatedClient:
-    if not self.token:
+    # Resolved per call: a configured `token_provider` wins over the
+    # static token, so rotating credentials are picked up per-request.
+    token = resolve_config_token(self.config)
+    if not token:
       raise RuntimeError("No API key provided. Set X-API-Key in headers.")
     return AuthenticatedClient(
       base_url=self.base_url,
-      token=self.token,
+      token=token,
       prefix="",
       auth_header_name="X-API-Key",
       headers=self.headers,
@@ -565,11 +579,12 @@ class LedgerClient:
     is passed to `execute()`, not the constructor, because it shapes
     the URL.
     """
-    if not self.token:
+    token = resolve_config_token(self.config)
+    if not token:
       raise RuntimeError("No API key provided. Set X-API-Key in headers.")
     return GraphQLClient(
       base_url=self.base_url,
-      token=self.token,
+      token=token,
       headers=self.headers,
       timeout=self.timeout,
     )
@@ -1103,6 +1118,20 @@ class LedgerClient:
     )
     return GetLedgerMappingCoverage.model_validate(data).mapping_coverage
 
+  def get_mapping_candidates(
+    self, graph_id: str, classification: str
+  ) -> list[MappingCandidatesMappingCandidates]:
+    """rs-gaap concepts a CoA element of the given EFS ``classification``
+    (asset / liability / equity / revenue / expense) may map to — limited
+    to concepts that render under the graph's active Reporting Style,
+    with statement-level subtotals excluded. Use this to populate the
+    mapping picker so it never offers an unreachable target.
+    """
+    data = self._query(
+      graph_id, MAPPING_CANDIDATES_GQL, {"classification": classification}
+    )
+    return MappingCandidates.model_validate(data).mapping_candidates
+
   def create_mapping_association(
     self,
     graph_id: str,
@@ -1156,16 +1185,42 @@ class LedgerClient:
     self,
     graph_id: str,
     block_id: str,
+    *,
+    scenario_id: str | None = None,
+    series: bool | None = None,
+    series_history: int | None = None,
+    series_forecast: int | None = None,
   ) -> InformationBlock | None:
     """Fetch an Information Block envelope by id — the cross-block-type read.
 
     Returns ``None`` when the block doesn't exist or its type isn't
     registered. See ``information-block.md`` for the envelope contract.
+
+    ``scenario_id`` selects the FactSet slice: ``None`` = actuals; a
+    forecast block's structure id = that scenario's parallel universe
+    (statement envelopes bind its latest computed month, metric
+    envelopes extend the series with "(forecast)"-labeled columns).
+
+    ``series`` renders a statement block as its whole report-set time
+    series — one column per period; combined with ``scenario_id`` the
+    columns cross the actuals/forecast seam and forecast columns carry
+    ``periods[].forecast == True``. Non-statement block types ignore it
+    (metric envelopes are always the full series).
+
+    ``series_history`` / ``series_forecast`` window the series to its
+    seam-adjacent columns — the last N actual columns and the first N
+    forecast columns; ``None`` = unbounded.
     """
     data = self._query(
       graph_id,
       GET_INFORMATION_BLOCK_GQL,
-      {"id": block_id},
+      {
+        "id": block_id,
+        "scenarioId": scenario_id,
+        "series": series,
+        "seriesHistory": series_history,
+        "seriesForecast": series_forecast,
+      },
     )
     return GetInformationBlock.model_validate(data).information_block
 
@@ -1385,6 +1440,41 @@ class LedgerClient:
     )
     envelope = self._call_op("Evaluate rules", response)
     return self._typed_result("Evaluate rules", envelope, EvaluateRulesResponse)
+
+  def compute_metrics(
+    self,
+    graph_id: str,
+    body: dict[str, Any],
+    *,
+    idempotency_key: str | None = None,
+  ) -> ComputeMetricsResponse:
+    """Compute a metric block's ``Derive`` rules for a period, upserting
+    the standing ``factset_type='metric'`` FactSet (one per structure +
+    entity + period_end; re-running a period replaces its facts).
+
+    Operands bind to the entity's most recent persisted report facts at
+    ``period_end``. Unresolvable metrics come back in ``skipped`` with a
+    reason rather than failing the run.
+
+    ``body`` accepts the fields of
+    :class:`robosystems_client.models.compute_metrics_request.ComputeMetricsRequest`:
+    ``structure_id``, ``period_end``, plus optional ``period_start``,
+    ``entity_id``, and ``scenario_id`` (pass a forecast block's structure
+    id after compute-forecast to extend the metric series into its
+    forward months).
+
+    Supply ``idempotency_key`` to make the call safe to retry — replays
+    within 24 hours return the same envelope.
+    """
+    request = ComputeMetricsRequest.from_dict(body)
+    response = op_compute_metrics(
+      graph_id=graph_id,
+      body=request,
+      client=self._get_client(),
+      idempotency_key=idempotency_key if idempotency_key is not None else UNSET,
+    )
+    envelope = self._call_op("Compute metrics", response)
+    return self._typed_result("Compute metrics", envelope, ComputeMetricsResponse)
 
   def update_schedule(
     self, graph_id: str, structure_id: str, body: dict[str, Any]
@@ -1937,12 +2027,15 @@ class LedgerClient:
     mapping_id: str,
     period_start: str,
     period_end: str,
-    taxonomy_id: str = "tax_usgaap_reporting",
+    taxonomy_id: str = "rs-gaap",
     period_type: str = "quarterly",
     comparative: bool = True,
   ) -> ReportResponse:
     """Generate report facts from the ledger and publish a Report
     definition. Synchronous — returns the published report header.
+
+    ``taxonomy_id`` defaults to ``"rs-gaap"``, the canonical reporting
+    vocabulary (matches the backend's ``CreateReportRequest`` default).
     """
     body = CreateReportRequest(
       name=name,

--- a/robosystems_client/clients/library_client.py
+++ b/robosystems_client/clients/library_client.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..graphql.client import GraphQLClient, strip_none_vars
+from .token_utils import resolve_config_token
 from ..graphql.generated.get_library_element import (
   GetLibraryElement,
 )
@@ -31,6 +32,10 @@ from ..graphql.generated.get_library_element import (
 from ..graphql.generated.get_library_element_arcs import (
   GetLibraryElementArcs,
   GetLibraryElementArcsLibraryElementArcs,
+)
+from ..graphql.generated.get_library_element_classifications import (
+  GetLibraryElementClassifications,
+  GetLibraryElementClassificationsLibraryElementClassifications,
 )
 from ..graphql.generated.get_library_element_equivalents import (
   GetLibraryElementEquivalents,
@@ -48,6 +53,10 @@ from ..graphql.generated.list_library_elements import (
   ListLibraryElements,
   ListLibraryElementsLibraryElements,
 )
+from ..graphql.generated.list_library_structures import (
+  ListLibraryStructures,
+  ListLibraryStructuresLibraryStructures,
+)
 from ..graphql.generated.list_library_taxonomies import (
   ListLibraryTaxonomies,
   ListLibraryTaxonomiesLibraryTaxonomies,
@@ -57,10 +66,12 @@ from ..graphql.generated.list_library_taxonomy_arcs import (
 )
 from ..graphql.generated.operations import (
   GET_LIBRARY_ELEMENT_ARCS_GQL,
+  GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL,
   GET_LIBRARY_ELEMENT_EQUIVALENTS_GQL,
   GET_LIBRARY_ELEMENT_GQL,
   GET_LIBRARY_TAXONOMY_GQL,
   LIST_LIBRARY_ELEMENTS_GQL,
+  LIST_LIBRARY_STRUCTURES_GQL,
   LIST_LIBRARY_TAXONOMIES_GQL,
   LIST_LIBRARY_TAXONOMY_ARCS_GQL,
   SEARCH_LIBRARY_ELEMENTS_GQL,
@@ -89,11 +100,14 @@ class LibraryClient:
     self.timeout = config.get("timeout", 60)
 
   def _get_graphql_client(self) -> GraphQLClient:
-    if not self.token:
+    # Resolved per call: a configured `token_provider` wins over the
+    # static token, so rotating credentials are picked up per-request.
+    token = resolve_config_token(self.config)
+    if not token:
       raise RuntimeError("No API key provided. Set token in config.")
     return GraphQLClient(
       base_url=self.base_url,
-      token=self.token,
+      token=token,
       headers=self.headers,
       timeout=self.timeout,
     )
@@ -221,10 +235,15 @@ class LibraryClient:
     graph_id: str = LIBRARY_GRAPH_ID,
     *,
     association_type: str | None = None,
+    structure_id: str | None = None,
     limit: int = 200,
     offset: int = 0,
   ) -> ListLibraryTaxonomyArcs:
     """All arcs contributed by a taxonomy plus their total count.
+
+    Pass ``structure_id`` to scope both the page and the count to one
+    structure's arcs — pair with :meth:`list_library_structures` to
+    load a single hierarchy at a time.
 
     Returns the typed response carrying both root fields:
     ``library_taxonomy_arcs`` (the page of arcs) and
@@ -236,11 +255,39 @@ class LibraryClient:
       {
         "taxonomyId": taxonomy_id,
         "associationType": association_type,
+        "structureId": structure_id,
         "limit": limit,
         "offset": offset,
       },
     )
     return ListLibraryTaxonomyArcs.model_validate(data)
+
+  # ── Structures ──────────────────────────────────────────────────────
+
+  def list_library_structures(
+    self,
+    graph_id: str = LIBRARY_GRAPH_ID,
+    *,
+    taxonomy_id: str | None = None,
+    block_type: str | None = None,
+  ) -> list[ListLibraryStructuresLibraryStructures]:
+    """List the structures (extended link roles) a taxonomy contributes —
+    the named presentation/calculation hierarchies (BS-classified,
+    IS-multistep, the calc DAG roots, …). Pair a structure's ``id`` with
+    :meth:`list_library_taxonomy_arcs` and its ``structure_id`` filter
+    to load just that hierarchy's arcs — the hierarchy view uses this to
+    scope a tree to one role at a time.
+
+    Pass ``taxonomy_id`` to scope to a single taxonomy; ``block_type``
+    to filter to one statement kind (balance_sheet, income_statement,
+    cash_flow_statement, …).
+    """
+    data = self._query(
+      graph_id,
+      LIST_LIBRARY_STRUCTURES_GQL,
+      {"taxonomyId": taxonomy_id, "blockType": block_type},
+    )
+    return ListLibraryStructures.model_validate(data).library_structures
 
   def get_library_element_arcs(
     self,
@@ -250,6 +297,20 @@ class LibraryClient:
     """All mapping arcs where this element is source or target."""
     data = self._query(graph_id, GET_LIBRARY_ELEMENT_ARCS_GQL, {"id": id})
     return GetLibraryElementArcs.model_validate(data).library_element_arcs
+
+  def get_library_element_classifications(
+    self,
+    id: str,
+    graph_id: str = LIBRARY_GRAPH_ID,
+  ) -> list[GetLibraryElementClassificationsLibraryElementClassifications]:
+    """All classification traits assigned to an element — every
+    category/identifier pair from element_classifications, sorted by
+    category then identifier.
+    """
+    data = self._query(graph_id, GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL, {"id": id})
+    return GetLibraryElementClassifications.model_validate(
+      data
+    ).library_element_classifications
 
   def get_library_element_equivalents(
     self,

--- a/robosystems_client/clients/token_utils.py
+++ b/robosystems_client/clients/token_utils.py
@@ -7,7 +7,7 @@ import base64
 import json
 import os
 from datetime import datetime, timedelta
-from typing import Dict, Any, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 from enum import Enum
 import logging
 
@@ -415,3 +415,31 @@ def extract_token_from_client(client) -> Optional[str]:
         return extract_jwt_from_header(config["headers"])
 
   return None
+
+
+# ── Dynamic credential resolution (token_provider) ─────────────────────
+
+# Zero-arg callable returning the current auth credential (or None for
+# "no credential available right now"). Mirrors the TypeScript client's
+# `TokenProvider`. Use instead of a static `token` when the credential
+# can rotate during the facade's lifetime (short-lived JWTs); it is
+# consulted on every request, so keep it cheap — an in-memory or
+# environment lookup, not a network call.
+TokenProvider = Callable[[], Optional[str]]
+
+
+def resolve_config_token(config: Dict[str, Any]) -> Optional[str]:
+  """Resolve the current auth credential from a facade config dict.
+
+  ``token_provider`` (a :data:`TokenProvider` callable) wins over the
+  static ``token`` when set — the facades call this on every request
+  (each `_get_client` / `_get_graphql_client` builds a fresh client),
+  so JWT refreshes are picked up without rebuilding the facade.
+
+  Pair with :class:`TokenManager` when you need refresh scheduling: keep
+  a manager instance and pass ``token_provider=manager.get_token``.
+  """
+  provider = config.get("token_provider")
+  if provider is not None:
+    return provider()
+  return config.get("token")

--- a/robosystems_client/graphql/generated/__init__.py
+++ b/robosystems_client/graphql/generated/__init__.py
@@ -25,6 +25,9 @@ from .get_information_block import (
   GetInformationBlockInformationBlockVerificationSummary,
   GetInformationBlockInformationBlockVerificationSummaryByCategory,
   GetInformationBlockInformationBlockView,
+  GetInformationBlockInformationBlockViewChart,
+  GetInformationBlockInformationBlockViewChartPanels,
+  GetInformationBlockInformationBlockViewChartPanelsSeries,
   GetInformationBlockInformationBlockViewRendering,
   GetInformationBlockInformationBlockViewRenderingPeriods,
   GetInformationBlockInformationBlockViewRenderingRows,
@@ -171,6 +174,10 @@ from .get_library_element_arcs import (
   GetLibraryElementArcsLibraryElementArcs,
   GetLibraryElementArcsLibraryElementArcsPeer,
 )
+from .get_library_element_classifications import (
+  GetLibraryElementClassifications,
+  GetLibraryElementClassificationsLibraryElementClassifications,
+)
 from .get_library_element_equivalents import (
   GetLibraryElementEquivalents,
   GetLibraryElementEquivalentsLibraryElementEquivalents,
@@ -280,6 +287,10 @@ from .list_library_elements import (
   ListLibraryElementsLibraryElementsLabels,
   ListLibraryElementsLibraryElementsReferences,
 )
+from .list_library_structures import (
+  ListLibraryStructures,
+  ListLibraryStructuresLibraryStructures,
+)
 from .list_library_taxonomies import (
   ListLibraryTaxonomies,
   ListLibraryTaxonomiesLibraryTaxonomies,
@@ -288,6 +299,7 @@ from .list_library_taxonomy_arcs import (
   ListLibraryTaxonomyArcs,
   ListLibraryTaxonomyArcsLibraryTaxonomyArcs,
 )
+from .mapping_candidates import MappingCandidates, MappingCandidatesMappingCandidates
 from .operations import (
   GET_INFORMATION_BLOCK_GQL,
   GET_INVESTOR_HOLDINGS_GQL,
@@ -316,6 +328,7 @@ from .operations import (
   GET_LEDGER_TRANSACTION_GQL,
   GET_LEDGER_TRIAL_BALANCE_GQL,
   GET_LIBRARY_ELEMENT_ARCS_GQL,
+  GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL,
   GET_LIBRARY_ELEMENT_EQUIVALENTS_GQL,
   GET_LIBRARY_ELEMENT_GQL,
   GET_LIBRARY_TAXONOMY_GQL,
@@ -336,8 +349,10 @@ from .operations import (
   LIST_LEDGER_TRANSACTIONS_GQL,
   LIST_LEDGER_UNMAPPED_ELEMENTS_GQL,
   LIST_LIBRARY_ELEMENTS_GQL,
+  LIST_LIBRARY_STRUCTURES_GQL,
   LIST_LIBRARY_TAXONOMIES_GQL,
   LIST_LIBRARY_TAXONOMY_ARCS_GQL,
+  MAPPING_CANDIDATES_GQL,
   SEARCH_LIBRARY_ELEMENTS_GQL,
 )
 from .search_library_elements import (
@@ -378,6 +393,7 @@ __all__ = [
   "GET_LEDGER_TRANSACTION_GQL",
   "GET_LEDGER_TRIAL_BALANCE_GQL",
   "GET_LIBRARY_ELEMENT_ARCS_GQL",
+  "GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL",
   "GET_LIBRARY_ELEMENT_EQUIVALENTS_GQL",
   "GET_LIBRARY_ELEMENT_GQL",
   "GET_LIBRARY_TAXONOMY_GQL",
@@ -396,6 +412,9 @@ __all__ = [
   "GetInformationBlockInformationBlockVerificationSummary",
   "GetInformationBlockInformationBlockVerificationSummaryByCategory",
   "GetInformationBlockInformationBlockView",
+  "GetInformationBlockInformationBlockViewChart",
+  "GetInformationBlockInformationBlockViewChartPanels",
+  "GetInformationBlockInformationBlockViewChartPanelsSeries",
   "GetInformationBlockInformationBlockViewRendering",
   "GetInformationBlockInformationBlockViewRenderingPeriods",
   "GetInformationBlockInformationBlockViewRenderingRows",
@@ -502,6 +521,8 @@ __all__ = [
   "GetLibraryElementArcs",
   "GetLibraryElementArcsLibraryElementArcs",
   "GetLibraryElementArcsLibraryElementArcsPeer",
+  "GetLibraryElementClassifications",
+  "GetLibraryElementClassificationsLibraryElementClassifications",
   "GetLibraryElementEquivalents",
   "GetLibraryElementEquivalentsLibraryElementEquivalents",
   "GetLibraryElementEquivalentsLibraryElementEquivalentsElement",
@@ -533,6 +554,7 @@ __all__ = [
   "LIST_LEDGER_TRANSACTIONS_GQL",
   "LIST_LEDGER_UNMAPPED_ELEMENTS_GQL",
   "LIST_LIBRARY_ELEMENTS_GQL",
+  "LIST_LIBRARY_STRUCTURES_GQL",
   "LIST_LIBRARY_TAXONOMIES_GQL",
   "LIST_LIBRARY_TAXONOMY_ARCS_GQL",
   "ListInformationBlocks",
@@ -609,10 +631,15 @@ __all__ = [
   "ListLibraryElementsLibraryElements",
   "ListLibraryElementsLibraryElementsLabels",
   "ListLibraryElementsLibraryElementsReferences",
+  "ListLibraryStructures",
+  "ListLibraryStructuresLibraryStructures",
   "ListLibraryTaxonomies",
   "ListLibraryTaxonomiesLibraryTaxonomies",
   "ListLibraryTaxonomyArcs",
   "ListLibraryTaxonomyArcsLibraryTaxonomyArcs",
+  "MAPPING_CANDIDATES_GQL",
+  "MappingCandidates",
+  "MappingCandidatesMappingCandidates",
   "ReportDownloadFormat",
   "SEARCH_LIBRARY_ELEMENTS_GQL",
   "SearchLibraryElements",

--- a/robosystems_client/graphql/generated/client.py
+++ b/robosystems_client/graphql/generated/client.py
@@ -31,6 +31,7 @@ from .get_ledger_transaction import GetLedgerTransaction
 from .get_ledger_trial_balance import GetLedgerTrialBalance
 from .get_library_element import GetLibraryElement
 from .get_library_element_arcs import GetLibraryElementArcs
+from .get_library_element_classifications import GetLibraryElementClassifications
 from .get_library_element_equivalents import GetLibraryElementEquivalents
 from .get_library_taxonomy import GetLibraryTaxonomy
 from .list_information_blocks import ListInformationBlocks
@@ -50,8 +51,10 @@ from .list_ledger_taxonomies import ListLedgerTaxonomies
 from .list_ledger_transactions import ListLedgerTransactions
 from .list_ledger_unmapped_elements import ListLedgerUnmappedElements
 from .list_library_elements import ListLibraryElements
+from .list_library_structures import ListLibraryStructures
 from .list_library_taxonomies import ListLibraryTaxonomies
 from .list_library_taxonomy_arcs import ListLibraryTaxonomyArcs
+from .mapping_candidates import MappingCandidates
 from .operations import (
   GET_INFORMATION_BLOCK_GQL,
   GET_INVESTOR_HOLDINGS_GQL,
@@ -80,6 +83,7 @@ from .operations import (
   GET_LEDGER_TRANSACTION_GQL,
   GET_LEDGER_TRIAL_BALANCE_GQL,
   GET_LIBRARY_ELEMENT_ARCS_GQL,
+  GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL,
   GET_LIBRARY_ELEMENT_EQUIVALENTS_GQL,
   GET_LIBRARY_ELEMENT_GQL,
   GET_LIBRARY_TAXONOMY_GQL,
@@ -100,8 +104,10 @@ from .operations import (
   LIST_LEDGER_TRANSACTIONS_GQL,
   LIST_LEDGER_UNMAPPED_ELEMENTS_GQL,
   LIST_LIBRARY_ELEMENTS_GQL,
+  LIST_LIBRARY_STRUCTURES_GQL,
   LIST_LIBRARY_TAXONOMIES_GQL,
   LIST_LIBRARY_TAXONOMY_ARCS_GQL,
+  MAPPING_CANDIDATES_GQL,
   SEARCH_LIBRARY_ELEMENTS_GQL,
 )
 from .search_library_elements import SearchLibraryElements
@@ -227,8 +233,22 @@ class Client(BaseClient):
     data = self.get_data(response)
     return ListInvestorSecurities.model_validate(data)
 
-  def get_information_block(self, id: str, **kwargs: Any) -> GetInformationBlock:
-    variables: dict[str, object] = {"id": id}
+  def get_information_block(
+    self,
+    id: str,
+    series: bool,
+    scenario_id: Union[Optional[str], UnsetType] = UNSET,
+    series_history: Union[Optional[int], UnsetType] = UNSET,
+    series_forecast: Union[Optional[int], UnsetType] = UNSET,
+    **kwargs: Any,
+  ) -> GetInformationBlock:
+    variables: dict[str, object] = {
+      "id": id,
+      "scenarioId": scenario_id,
+      "series": series,
+      "seriesHistory": series_history,
+      "seriesForecast": series_forecast,
+    }
     response = self.execute(
       query=GET_INFORMATION_BLOCK_GQL,
       operation_name="GetInformationBlock",
@@ -768,6 +788,17 @@ class Client(BaseClient):
     data = self.get_data(response)
     return ListLedgerUnmappedElements.model_validate(data)
 
+  def mapping_candidates(self, classification: str, **kwargs: Any) -> MappingCandidates:
+    variables: dict[str, object] = {"classification": classification}
+    response = self.execute(
+      query=MAPPING_CANDIDATES_GQL,
+      operation_name="MappingCandidates",
+      variables=variables,
+      **kwargs,
+    )
+    data = self.get_data(response)
+    return MappingCandidates.model_validate(data)
+
   def get_library_element(
     self,
     id: Union[Optional[str], UnsetType] = UNSET,
@@ -794,6 +825,19 @@ class Client(BaseClient):
     )
     data = self.get_data(response)
     return GetLibraryElementArcs.model_validate(data)
+
+  def get_library_element_classifications(
+    self, id: str, **kwargs: Any
+  ) -> GetLibraryElementClassifications:
+    variables: dict[str, object] = {"id": id}
+    response = self.execute(
+      query=GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL,
+      operation_name="GetLibraryElementClassifications",
+      variables=variables,
+      **kwargs,
+    )
+    data = self.get_data(response)
+    return GetLibraryElementClassifications.model_validate(data)
 
   def get_library_element_equivalents(
     self, id: str, **kwargs: Any
@@ -866,6 +910,25 @@ class Client(BaseClient):
     data = self.get_data(response)
     return ListLibraryElements.model_validate(data)
 
+  def list_library_structures(
+    self,
+    taxonomy_id: Union[Optional[str], UnsetType] = UNSET,
+    block_type: Union[Optional[str], UnsetType] = UNSET,
+    **kwargs: Any,
+  ) -> ListLibraryStructures:
+    variables: dict[str, object] = {
+      "taxonomyId": taxonomy_id,
+      "blockType": block_type,
+    }
+    response = self.execute(
+      query=LIST_LIBRARY_STRUCTURES_GQL,
+      operation_name="ListLibraryStructures",
+      variables=variables,
+      **kwargs,
+    )
+    data = self.get_data(response)
+    return ListLibraryStructures.model_validate(data)
+
   def list_library_taxonomies(
     self,
     include_element_count: bool,
@@ -891,11 +954,13 @@ class Client(BaseClient):
     limit: int,
     offset: int,
     association_type: Union[Optional[str], UnsetType] = UNSET,
+    structure_id: Union[Optional[str], UnsetType] = UNSET,
     **kwargs: Any,
   ) -> ListLibraryTaxonomyArcs:
     variables: dict[str, object] = {
       "taxonomyId": taxonomy_id,
       "associationType": association_type,
+      "structureId": structure_id,
       "limit": limit,
       "offset": offset,
     }

--- a/robosystems_client/graphql/generated/get_information_block.py
+++ b/robosystems_client/graphql/generated/get_information_block.py
@@ -123,6 +123,7 @@ class GetInformationBlockInformationBlockFactSet(BaseModel):
   factset_type: str = Field(alias="factsetType")
   entity_id: str = Field(alias="entityId")
   report_id: Optional[str] = Field(alias="reportId")
+  scenario_id: Optional[str] = Field(alias="scenarioId")
   provenance: Optional[Any]
 
 
@@ -160,6 +161,7 @@ class GetInformationBlockInformationBlockVerificationSummaryByCategory(BaseModel
 
 class GetInformationBlockInformationBlockView(BaseModel):
   rendering: Optional["GetInformationBlockInformationBlockViewRendering"]
+  chart: Optional["GetInformationBlockInformationBlockViewChart"]
 
 
 class GetInformationBlockInformationBlockViewRendering(BaseModel):
@@ -175,6 +177,7 @@ class GetInformationBlockInformationBlockViewRenderingRows(BaseModel):
   element_name: str = Field(alias="elementName")
   classification: Optional[str]
   balance_type: Optional[str] = Field(alias="balanceType")
+  item_type: Optional[str] = Field(alias="itemType")
   values: list[Optional[float]]
   text_value: Optional[str] = Field(alias="textValue")
   is_subtotal: bool = Field(alias="isSubtotal")
@@ -185,6 +188,7 @@ class GetInformationBlockInformationBlockViewRenderingPeriods(BaseModel):
   start: str
   end: str
   label: Optional[str]
+  forecast: Optional[bool]
 
 
 class GetInformationBlockInformationBlockViewRenderingValidation(BaseModel):
@@ -194,9 +198,28 @@ class GetInformationBlockInformationBlockViewRenderingValidation(BaseModel):
   warnings: list[str]
 
 
+class GetInformationBlockInformationBlockViewChart(BaseModel):
+  panels: list["GetInformationBlockInformationBlockViewChartPanels"]
+
+
+class GetInformationBlockInformationBlockViewChartPanels(BaseModel):
+  label: Optional[str]
+  item_type: Optional[str] = Field(alias="itemType")
+  kind: str
+  series: list["GetInformationBlockInformationBlockViewChartPanelsSeries"]
+
+
+class GetInformationBlockInformationBlockViewChartPanelsSeries(BaseModel):
+  key: str
+  element_id: str = Field(alias="elementId")
+  label: str
+
+
 GetInformationBlock.model_rebuild()
 GetInformationBlockInformationBlock.model_rebuild()
 GetInformationBlockInformationBlockRules.model_rebuild()
 GetInformationBlockInformationBlockVerificationSummary.model_rebuild()
 GetInformationBlockInformationBlockView.model_rebuild()
 GetInformationBlockInformationBlockViewRendering.model_rebuild()
+GetInformationBlockInformationBlockViewChart.model_rebuild()
+GetInformationBlockInformationBlockViewChartPanels.model_rebuild()

--- a/robosystems_client/graphql/generated/get_library_element_classifications.py
+++ b/robosystems_client/graphql/generated/get_library_element_classifications.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class GetLibraryElementClassifications(BaseModel):
+  library_element_classifications: list[
+    "GetLibraryElementClassificationsLibraryElementClassifications"
+  ] = Field(alias="libraryElementClassifications")
+
+
+class GetLibraryElementClassificationsLibraryElementClassifications(BaseModel):
+  category: str
+  identifier: str
+  name: Optional[str]
+  is_primary: bool = Field(alias="isPrimary")
+
+
+GetLibraryElementClassifications.model_rebuild()

--- a/robosystems_client/graphql/generated/list_library_structures.py
+++ b/robosystems_client/graphql/generated/list_library_structures.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class ListLibraryStructures(BaseModel):
+  library_structures: list["ListLibraryStructuresLibraryStructures"] = Field(
+    alias="libraryStructures"
+  )
+
+
+class ListLibraryStructuresLibraryStructures(BaseModel):
+  id: str
+  name: str
+  block_type: str = Field(alias="blockType")
+  taxonomy_id: str = Field(alias="taxonomyId")
+  role_uri: Optional[str] = Field(alias="roleUri")
+  is_active: bool = Field(alias="isActive")
+
+
+ListLibraryStructures.model_rebuild()

--- a/robosystems_client/graphql/generated/list_library_taxonomy_arcs.py
+++ b/robosystems_client/graphql/generated/list_library_taxonomy_arcs.py
@@ -19,9 +19,13 @@ class ListLibraryTaxonomyArcsLibraryTaxonomyArcs(BaseModel):
   from_element_id: str = Field(alias="fromElementId")
   from_element_qname: Optional[str] = Field(alias="fromElementQname")
   from_element_name: Optional[str] = Field(alias="fromElementName")
+  from_element_trait: Optional[str] = Field(alias="fromElementTrait")
+  from_element_is_abstract: Optional[bool] = Field(alias="fromElementIsAbstract")
   to_element_id: str = Field(alias="toElementId")
   to_element_qname: Optional[str] = Field(alias="toElementQname")
   to_element_name: Optional[str] = Field(alias="toElementName")
+  to_element_trait: Optional[str] = Field(alias="toElementTrait")
+  to_element_is_abstract: Optional[bool] = Field(alias="toElementIsAbstract")
   association_type: str = Field(alias="associationType")
   arcrole: Optional[str]
   order_value: Optional[float] = Field(alias="orderValue")

--- a/robosystems_client/graphql/generated/mapping_candidates.py
+++ b/robosystems_client/graphql/generated/mapping_candidates.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class MappingCandidates(BaseModel):
+  mapping_candidates: list["MappingCandidatesMappingCandidates"] = Field(
+    alias="mappingCandidates"
+  )
+
+
+class MappingCandidatesMappingCandidates(BaseModel):
+  id: str
+  name: str
+  qname: Optional[str]
+  trait: Optional[str]
+
+
+MappingCandidates.model_rebuild()

--- a/robosystems_client/graphql/generated/operations.py
+++ b/robosystems_client/graphql/generated/operations.py
@@ -26,6 +26,7 @@ __all__ = [
   "GET_LEDGER_TRANSACTION_GQL",
   "GET_LEDGER_TRIAL_BALANCE_GQL",
   "GET_LIBRARY_ELEMENT_ARCS_GQL",
+  "GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL",
   "GET_LIBRARY_ELEMENT_EQUIVALENTS_GQL",
   "GET_LIBRARY_ELEMENT_GQL",
   "GET_LIBRARY_TAXONOMY_GQL",
@@ -46,8 +47,10 @@ __all__ = [
   "LIST_LEDGER_TRANSACTIONS_GQL",
   "LIST_LEDGER_UNMAPPED_ELEMENTS_GQL",
   "LIST_LIBRARY_ELEMENTS_GQL",
+  "LIST_LIBRARY_STRUCTURES_GQL",
   "LIST_LIBRARY_TAXONOMIES_GQL",
   "LIST_LIBRARY_TAXONOMY_ARCS_GQL",
+  "MAPPING_CANDIDATES_GQL",
   "SEARCH_LIBRARY_ELEMENTS_GQL",
 ]
 
@@ -271,8 +274,14 @@ query ListInvestorSecurities($entityId: String, $securityType: String, $isActive
 """
 
 GET_INFORMATION_BLOCK_GQL = """
-query GetInformationBlock($id: ID!) {
-  informationBlock(id: $id) {
+query GetInformationBlock($id: ID!, $scenarioId: String, $series: Boolean! = false, $seriesHistory: Int, $seriesForecast: Int) {
+  informationBlock(
+    id: $id
+    scenarioId: $scenarioId
+    series: $series
+    seriesHistory: $seriesHistory
+    seriesForecast: $seriesForecast
+  ) {
     id
     blockType
     name
@@ -350,6 +359,7 @@ query GetInformationBlock($id: ID!) {
       factsetType
       entityId
       reportId
+      scenarioId
       provenance
     }
     verificationResults {
@@ -386,6 +396,7 @@ query GetInformationBlock($id: ID!) {
           elementName
           classification
           balanceType
+          itemType
           values
           textValue
           isSubtotal
@@ -395,6 +406,7 @@ query GetInformationBlock($id: ID!) {
           start
           end
           label
+          forecast
         }
         validation {
           passed
@@ -403,6 +415,18 @@ query GetInformationBlock($id: ID!) {
           warnings
         }
         unmappedCount
+      }
+      chart {
+        panels {
+          label
+          itemType
+          kind
+          series {
+            key
+            elementId
+            label
+          }
+        }
       }
     }
   }
@@ -1588,6 +1612,17 @@ query ListLedgerUnmappedElements($mappingId: String) {
 }
 """
 
+MAPPING_CANDIDATES_GQL = """
+query MappingCandidates($classification: String!) {
+  mappingCandidates(classification: $classification) {
+    id
+    name
+    qname
+    trait
+  }
+}
+"""
+
 GET_LIBRARY_ELEMENT_GQL = """
 query GetLibraryElement($id: ID, $qname: String) {
   libraryElement(id: $id, qname: $qname) {
@@ -1637,6 +1672,17 @@ query GetLibraryElementArcs($id: ID!) {
       trait
       source
     }
+  }
+}
+"""
+
+GET_LIBRARY_ELEMENT_CLASSIFICATIONS_GQL = """
+query GetLibraryElementClassifications($id: ID!) {
+  libraryElementClassifications(id: $id) {
+    category
+    identifier
+    name
+    isPrimary
   }
 }
 """
@@ -1726,6 +1772,19 @@ query ListLibraryElements($taxonomyId: ID, $source: String, $classification: Str
 }
 """
 
+LIST_LIBRARY_STRUCTURES_GQL = """
+query ListLibraryStructures($taxonomyId: ID, $blockType: String) {
+  libraryStructures(taxonomyId: $taxonomyId, blockType: $blockType) {
+    id
+    name
+    blockType
+    taxonomyId
+    roleUri
+    isActive
+  }
+}
+"""
+
 LIST_LIBRARY_TAXONOMIES_GQL = """
 query ListLibraryTaxonomies($standard: String, $includeElementCount: Boolean! = false) {
   libraryTaxonomies(
@@ -1748,11 +1807,16 @@ query ListLibraryTaxonomies($standard: String, $includeElementCount: Boolean! = 
 """
 
 LIST_LIBRARY_TAXONOMY_ARCS_GQL = """
-query ListLibraryTaxonomyArcs($taxonomyId: ID!, $associationType: String, $limit: Int! = 200, $offset: Int! = 0) {
-  libraryTaxonomyArcCount(taxonomyId: $taxonomyId)
+query ListLibraryTaxonomyArcs($taxonomyId: ID!, $associationType: String, $structureId: ID, $limit: Int! = 200, $offset: Int! = 0) {
+  libraryTaxonomyArcCount(
+    taxonomyId: $taxonomyId
+    associationType: $associationType
+    structureId: $structureId
+  )
   libraryTaxonomyArcs(
     taxonomyId: $taxonomyId
     associationType: $associationType
+    structureId: $structureId
     limit: $limit
     offset: $offset
   ) {
@@ -1762,9 +1826,13 @@ query ListLibraryTaxonomyArcs($taxonomyId: ID!, $associationType: String, $limit
     fromElementId
     fromElementQname
     fromElementName
+    fromElementTrait
+    fromElementIsAbstract
     toElementId
     toElementQname
     toElementName
+    toElementTrait
+    toElementIsAbstract
     associationType
     arcrole
     orderValue

--- a/robosystems_client/graphql/operations/ledger/GetInformationBlock.graphql
+++ b/robosystems_client/graphql/operations/ledger/GetInformationBlock.graphql
@@ -1,5 +1,17 @@
-query GetInformationBlock($id: ID!) {
-  informationBlock(id: $id) {
+query GetInformationBlock(
+  $id: ID!
+  $scenarioId: String
+  $series: Boolean! = false
+  $seriesHistory: Int
+  $seriesForecast: Int
+) {
+  informationBlock(
+    id: $id
+    scenarioId: $scenarioId
+    series: $series
+    seriesHistory: $seriesHistory
+    seriesForecast: $seriesForecast
+  ) {
     id blockType name displayName category
     taxonomyId taxonomyName
     informationModel { conceptArrangement memberArrangement }
@@ -24,7 +36,7 @@ query GetInformationBlock($id: ID!) {
     }
     factSet {
       id structureId periodStart periodEnd
-      factsetType entityId reportId provenance
+      factsetType entityId reportId scenarioId provenance
     }
     verificationResults {
       id ruleId structureId factSetId status message
@@ -38,11 +50,17 @@ query GetInformationBlock($id: ID!) {
       rendering {
         rows {
           elementId elementQname elementName classification
-          balanceType values textValue isSubtotal depth
+          balanceType itemType values textValue isSubtotal depth
         }
-        periods { start end label }
+        periods { start end label forecast }
         validation { passed checks failures warnings }
         unmappedCount
+      }
+      chart {
+        panels {
+          label itemType kind
+          series { key elementId label }
+        }
       }
     }
   }

--- a/robosystems_client/graphql/operations/ledger/MappingCandidates.graphql
+++ b/robosystems_client/graphql/operations/ledger/MappingCandidates.graphql
@@ -1,0 +1,8 @@
+query MappingCandidates($classification: String!) {
+  mappingCandidates(classification: $classification) {
+    id
+    name
+    qname
+    trait
+  }
+}

--- a/robosystems_client/graphql/operations/library/GetLibraryElementClassifications.graphql
+++ b/robosystems_client/graphql/operations/library/GetLibraryElementClassifications.graphql
@@ -1,0 +1,8 @@
+query GetLibraryElementClassifications($id: ID!) {
+  libraryElementClassifications(id: $id) {
+    category
+    identifier
+    name
+    isPrimary
+  }
+}

--- a/robosystems_client/graphql/operations/library/ListLibraryStructures.graphql
+++ b/robosystems_client/graphql/operations/library/ListLibraryStructures.graphql
@@ -1,0 +1,10 @@
+query ListLibraryStructures($taxonomyId: ID, $blockType: String) {
+  libraryStructures(taxonomyId: $taxonomyId, blockType: $blockType) {
+    id
+    name
+    blockType
+    taxonomyId
+    roleUri
+    isActive
+  }
+}

--- a/robosystems_client/graphql/operations/library/ListLibraryTaxonomyArcs.graphql
+++ b/robosystems_client/graphql/operations/library/ListLibraryTaxonomyArcs.graphql
@@ -1,13 +1,19 @@
 query ListLibraryTaxonomyArcs(
   $taxonomyId: ID!
   $associationType: String
+  $structureId: ID
   $limit: Int! = 200
   $offset: Int! = 0
 ) {
-  libraryTaxonomyArcCount(taxonomyId: $taxonomyId)
+  libraryTaxonomyArcCount(
+    taxonomyId: $taxonomyId
+    associationType: $associationType
+    structureId: $structureId
+  )
   libraryTaxonomyArcs(
     taxonomyId: $taxonomyId
     associationType: $associationType
+    structureId: $structureId
     limit: $limit
     offset: $offset
   ) {
@@ -17,9 +23,13 @@ query ListLibraryTaxonomyArcs(
     fromElementId
     fromElementQname
     fromElementName
+    fromElementTrait
+    fromElementIsAbstract
     toElementId
     toElementQname
     toElementName
+    toElementTrait
+    toElementIsAbstract
     associationType
     arcrole
     orderValue

--- a/tests/test_extensions_integration.py
+++ b/tests/test_extensions_integration.py
@@ -44,10 +44,22 @@ class TestAuthenticatedIntegration:
     )
 
   def test_authenticated_extensions_initialization(self, extensions, mock_api_key):
-    """Test that authenticated extensions initialize correctly"""
+    """Credentials route to exactly ONE header by shape — a non-rfs
+    credential rides in Authorization: Bearer, and no guaranteed-invalid
+    X-API-Key copy is sent alongside it."""
     assert extensions.config["base_url"] == "https://api.test.robosystems.ai"
-    assert extensions.config["headers"]["X-API-Key"] == mock_api_key
     assert extensions.config["headers"]["Authorization"] == f"Bearer {mock_api_key}"
+    assert "X-API-Key" not in extensions.config["headers"]
+
+  def test_authenticated_extensions_rfs_key_routes_to_x_api_key(self):
+    """rfs… API keys ride in X-API-Key only — never duplicated into a
+    guaranteed-invalid Authorization: Bearer header."""
+    ext = AuthenticatedClients(
+      api_key="rfs_live_key_123",
+      config=RoboSystemsClientConfig(base_url="https://api.test.robosystems.ai"),
+    )
+    assert ext.config["headers"]["X-API-Key"] == "rfs_live_key_123"
+    assert "Authorization" not in ext.config["headers"]
 
   def test_create_clients_factory(self, mock_api_key):
     """Test the extensions factory function"""

--- a/tests/test_ledger_client.py
+++ b/tests/test_ledger_client.py
@@ -1254,7 +1254,7 @@ class TestLedgerReadsAdditional:
         "factSet": None,
         "verificationResults": [],
         "verificationSummary": None,
-        "view": {"rendering": None},
+        "view": {"rendering": None, "chart": None},
       }
     }
     client = LedgerClient(mock_config)
@@ -2077,3 +2077,119 @@ def test_parse_filename_missing_returns_none():
 
   assert _parse_filename("") is None
   assert _parse_filename("attachment") is None
+
+
+# ── Mapping candidates ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMappingCandidates:
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_mapping_candidates(self, mock_execute, mock_config, graph_id):
+    mock_execute.return_value = {
+      "mappingCandidates": [
+        {
+          "id": "el_1",
+          "name": "Cash",
+          "qname": "rs-gaap:Cash",
+          "trait": "asset",
+        }
+      ]
+    }
+    client = LedgerClient(mock_config)
+    candidates = client.get_mapping_candidates(graph_id, "asset")
+    assert len(candidates) == 1
+    assert candidates[0].qname == "rs-gaap:Cash"
+    assert mock_execute.call_args[0][0] == graph_id
+    variables = mock_execute.call_args[0][2]
+    assert variables == {"classification": "asset"}
+
+
+# ── Information block read options ─────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestInformationBlockReadOptions:
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_information_block_strips_unset_options(
+    self, mock_execute, mock_config, graph_id
+  ):
+    mock_execute.return_value = {"informationBlock": None}
+    client = LedgerClient(mock_config)
+    assert client.get_information_block(graph_id, "blk_1") is None
+    # Only `id` goes over the wire — unset options are stripped, so the
+    # document's defaults apply (series=false, no scenario, no window).
+    variables = mock_execute.call_args[0][2]
+    assert variables == {"id": "blk_1"}
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_information_block_forwards_scenario_series_window(
+    self, mock_execute, mock_config, graph_id
+  ):
+    mock_execute.return_value = {"informationBlock": None}
+    client = LedgerClient(mock_config)
+    client.get_information_block(
+      graph_id,
+      "blk_1",
+      scenario_id="struct_fc",
+      series=True,
+      series_history=6,
+      series_forecast=12,
+    )
+    variables = mock_execute.call_args[0][2]
+    assert variables == {
+      "id": "blk_1",
+      "scenarioId": "struct_fc",
+      "series": True,
+      "seriesHistory": 6,
+      "seriesForecast": 12,
+    }
+
+
+# ── Compute metrics ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestComputeMetrics:
+  @patch("robosystems_client.clients.ledger_client.op_compute_metrics")
+  def test_compute_metrics(self, mock_op, mock_config, graph_id):
+    envelope = _envelope(
+      "compute-metrics",
+      {
+        "structure_id": "struct_m",
+        "period_end": "2026-06-30",
+        "computed": [{"element_id": "el_ratio", "value": 1.5}],
+        "skipped": [],
+      },
+    )
+    mock_op.return_value = _mock_response(envelope)
+    client = LedgerClient(mock_config)
+    result = client.compute_metrics(
+      graph_id, {"structure_id": "struct_m", "period_end": "2026-06-30"}
+    )
+    assert result["computed"][0]["element_id"] == "el_ratio"
+    assert mock_op.call_args.kwargs["graph_id"] == graph_id
+    body = mock_op.call_args.kwargs["body"]
+    assert body.structure_id == "struct_m"
+    assert body.period_end.isoformat() == "2026-06-30"
+    assert mock_op.call_args.kwargs["idempotency_key"] is UNSET
+
+  @patch("robosystems_client.clients.ledger_client.op_compute_metrics")
+  def test_compute_metrics_forwards_scenario_and_idempotency_key(
+    self, mock_op, mock_config, graph_id
+  ):
+    envelope = _envelope("compute-metrics", {"computed": [], "skipped": []})
+    mock_op.return_value = _mock_response(envelope)
+    client = LedgerClient(mock_config)
+    client.compute_metrics(
+      graph_id,
+      {
+        "structure_id": "struct_m",
+        "period_end": "2026-06-30",
+        "scenario_id": "struct_fc",
+      },
+      idempotency_key="idem-metrics-1",
+    )
+    body = mock_op.call_args.kwargs["body"]
+    assert body.scenario_id == "struct_fc"
+    assert mock_op.call_args.kwargs["idempotency_key"] == "idem-metrics-1"

--- a/tests/test_library_client.py
+++ b/tests/test_library_client.py
@@ -1,0 +1,412 @@
+"""Unit tests for LibraryClient.
+
+LibraryClient is read-only and speaks a single wire protocol: GraphQL at
+POST /extensions/{graph_id}/graphql, where ``graph_id`` is either the
+``"library"`` sentinel (canonical public-schema browse) or a tenant
+graph id (tenant copy + extensions).
+
+These tests mock at the transport boundary — ``GraphQLClient.execute``
+is patched exactly like tests/test_ledger_client.py does for ledger
+reads — and assert both the typed model validation of responses and the
+variables forwarded on the wire.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from robosystems_client.clients.library_client import (
+  LIBRARY_GRAPH_ID,
+  LibraryClient,
+)
+
+
+# ── Shared element payload helpers ─────────────────────────────────────
+
+
+def _element(id: str = "el_1", qname: str = "rs-gaap:Cash") -> dict:
+  """A full element payload matching the list/search/get selection set."""
+  return {
+    "id": id,
+    "qname": qname,
+    "namespace": "https://taxonomy.robosystems.ai/rs-gaap",
+    "name": "Cash",
+    "trait": "asset",
+    "balanceType": "debit",
+    "periodType": "instant",
+    "isAbstract": False,
+    "isMonetary": True,
+    "elementType": "monetaryItemType",
+    "source": "rs-gaap",
+    "taxonomyId": "tax_rsgaap",
+    "parentId": None,
+    "labels": [{"role": "label", "language": "en", "text": "Cash"}],
+    "references": [],
+  }
+
+
+def _taxonomy(id: str = "tax_rsgaap") -> dict:
+  return {
+    "id": id,
+    "name": "RoboSystems GAAP",
+    "description": None,
+    "standard": "rs-gaap",
+    "version": "2026",
+    "namespaceUri": "https://taxonomy.robosystems.ai/rs-gaap",
+    "taxonomyType": "reporting",
+    "isShared": True,
+    "isActive": True,
+    "isLocked": True,
+    "elementCount": 512,
+  }
+
+
+# ── Init ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLibraryClientInit:
+  def test_client_initialization(self, mock_config):
+    client = LibraryClient(mock_config)
+    assert client.base_url == "http://localhost:8000"
+    assert client.token == "test-api-key"
+    assert client.headers == {"X-API-Key": "test-api-key"}
+    assert client.timeout == 60
+
+  def test_get_graphql_client_no_token(self, mock_config):
+    mock_config["token"] = None
+    client = LibraryClient(mock_config)
+    with pytest.raises(RuntimeError, match="No API key"):
+      client._get_graphql_client()
+
+  @patch("robosystems_client.clients.library_client.GraphQLClient")
+  def test_token_provider_wins_over_static_token(self, mock_gql, mock_config):
+    """A configured token_provider is consulted per request and takes
+    precedence over the static token."""
+    mock_config["token_provider"] = lambda: "rfs_rotated"
+    client = LibraryClient(mock_config)
+    mock_gql.return_value.execute.return_value = {"libraryTaxonomies": []}
+    client.list_library_taxonomies()
+    assert mock_gql.call_args.kwargs["token"] == "rfs_rotated"
+
+
+# ── Taxonomies ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLibraryTaxonomies:
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_list_library_taxonomies(self, mock_execute, mock_config):
+    mock_execute.return_value = {"libraryTaxonomies": [_taxonomy()]}
+    client = LibraryClient(mock_config)
+    taxonomies = client.list_library_taxonomies()
+    assert len(taxonomies) == 1
+    assert taxonomies[0].id == "tax_rsgaap"
+    assert taxonomies[0].taxonomy_type == "reporting"
+    assert taxonomies[0].element_count == 512
+    # Defaults to the "library" sentinel graph
+    assert mock_execute.call_args[0][0] == LIBRARY_GRAPH_ID
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_list_library_taxonomies_forwards_filters(self, mock_execute, mock_config):
+    mock_execute.return_value = {"libraryTaxonomies": []}
+    client = LibraryClient(mock_config)
+    client.list_library_taxonomies(
+      "kg1a2b3c", standard="rs-gaap", include_element_count=True
+    )
+    # Tenant graph_id passes through as the first positional arg
+    assert mock_execute.call_args[0][0] == "kg1a2b3c"
+    variables = mock_execute.call_args[0][2]
+    assert variables["standard"] == "rs-gaap"
+    assert variables["includeElementCount"] is True
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_taxonomy(self, mock_execute, mock_config):
+    mock_execute.return_value = {"libraryTaxonomy": _taxonomy()}
+    client = LibraryClient(mock_config)
+    taxonomy = client.get_library_taxonomy(standard="rs-gaap", version="2026")
+    assert taxonomy is not None
+    assert taxonomy.standard == "rs-gaap"
+    variables = mock_execute.call_args[0][2]
+    assert variables["standard"] == "rs-gaap"
+    assert variables["version"] == "2026"
+    # None-valued variables are stripped before sending
+    assert "id" not in variables
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_taxonomy_returns_none_when_missing(
+    self, mock_execute, mock_config
+  ):
+    mock_execute.return_value = {"libraryTaxonomy": None}
+    client = LibraryClient(mock_config)
+    assert client.get_library_taxonomy(id="tax_nope") is None
+
+
+# ── Elements ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLibraryElements:
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_list_library_elements(self, mock_execute, mock_config):
+    payload = _element()
+    # The list read omits labels/references unless requested
+    del payload["labels"], payload["references"]
+    mock_execute.return_value = {"libraryElements": [payload]}
+    client = LibraryClient(mock_config)
+    elements = client.list_library_elements(
+      classification="asset", activity_type="operatingActivity", limit=10
+    )
+    assert len(elements) == 1
+    assert elements[0].qname == "rs-gaap:Cash"
+    assert elements[0].balance_type == "debit"
+    variables = mock_execute.call_args[0][2]
+    assert variables["classification"] == "asset"
+    assert variables["activityType"] == "operatingActivity"
+    assert variables["limit"] == 10
+    assert variables["includeLabels"] is False
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_search_library_elements(self, mock_execute, mock_config):
+    mock_execute.return_value = {"searchLibraryElements": [_element()]}
+    client = LibraryClient(mock_config)
+    results = client.search_library_elements("cash", source="rs-gaap", limit=5)
+    assert len(results) == 1
+    assert results[0].labels[0].text == "Cash"
+    variables = mock_execute.call_args[0][2]
+    assert variables["query"] == "cash"
+    assert variables["source"] == "rs-gaap"
+    assert variables["limit"] == 5
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_element_by_qname(self, mock_execute, mock_config):
+    mock_execute.return_value = {"libraryElement": _element()}
+    client = LibraryClient(mock_config)
+    element = client.get_library_element(qname="rs-gaap:Cash")
+    assert element is not None
+    assert element.is_monetary is True
+    variables = mock_execute.call_args[0][2]
+    assert variables["qname"] == "rs-gaap:Cash"
+    assert "id" not in variables
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_element_returns_none_when_missing(
+    self, mock_execute, mock_config
+  ):
+    mock_execute.return_value = {"libraryElement": None}
+    client = LibraryClient(mock_config)
+    assert client.get_library_element(id="el_nope") is None
+
+
+# ── Arcs ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLibraryArcs:
+  _ARC = {
+    "id": "arc_1",
+    "structureId": "struct_1",
+    "structureName": "BS-classified",
+    "fromElementId": "el_1",
+    "fromElementQname": "sfac6:Assets",
+    "fromElementName": "Assets",
+    "fromElementTrait": "asset",
+    "fromElementIsAbstract": True,
+    "toElementId": "el_2",
+    "toElementQname": "rs-gaap:Cash",
+    "toElementName": "Cash",
+    "toElementTrait": "asset",
+    "toElementIsAbstract": False,
+    "associationType": "presentation",
+    "arcrole": None,
+    "orderValue": 1.0,
+    "weight": None,
+  }
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_list_library_taxonomy_arcs(self, mock_execute, mock_config):
+    mock_execute.return_value = {
+      "libraryTaxonomyArcCount": 42,
+      "libraryTaxonomyArcs": [self._ARC],
+    }
+    client = LibraryClient(mock_config)
+    result = client.list_library_taxonomy_arcs("tax_rsgaap")
+    # Typed response carries both root fields
+    assert result.library_taxonomy_arc_count == 42
+    assert len(result.library_taxonomy_arcs) == 1
+    arc = result.library_taxonomy_arcs[0]
+    assert arc.from_element_trait == "asset"
+    assert arc.to_element_is_abstract is False
+    variables = mock_execute.call_args[0][2]
+    assert variables["taxonomyId"] == "tax_rsgaap"
+    # Optional filters stripped when not provided
+    assert "structureId" not in variables
+    assert "associationType" not in variables
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_list_library_taxonomy_arcs_structure_id_filter(
+    self, mock_execute, mock_config
+  ):
+    mock_execute.return_value = {
+      "libraryTaxonomyArcCount": 1,
+      "libraryTaxonomyArcs": [self._ARC],
+    }
+    client = LibraryClient(mock_config)
+    result = client.list_library_taxonomy_arcs(
+      "tax_rsgaap",
+      association_type="presentation",
+      structure_id="struct_1",
+      limit=50,
+      offset=10,
+    )
+    assert result.library_taxonomy_arc_count == 1
+    variables = mock_execute.call_args[0][2]
+    assert variables["structureId"] == "struct_1"
+    assert variables["associationType"] == "presentation"
+    assert variables["limit"] == 50
+    assert variables["offset"] == 10
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_element_arcs(self, mock_execute, mock_config):
+    mock_execute.return_value = {
+      "libraryElementArcs": [
+        {
+          "id": "arc_1",
+          "direction": "outgoing",
+          "associationType": "general-special",
+          "arcrole": None,
+          "taxonomyId": "tax_map",
+          "taxonomyStandard": "fac-to-rs-gaap",
+          "taxonomyName": "FAC to RS-GAAP",
+          "structureId": "struct_1",
+          "structureName": None,
+          "peer": {
+            "id": "el_2",
+            "qname": "rs-gaap:Cash",
+            "name": "Cash",
+            "trait": "asset",
+            "source": "rs-gaap",
+          },
+        }
+      ]
+    }
+    client = LibraryClient(mock_config)
+    arcs = client.get_library_element_arcs("el_1")
+    assert len(arcs) == 1
+    assert arcs[0].direction == "outgoing"
+    assert arcs[0].peer.qname == "rs-gaap:Cash"
+    variables = mock_execute.call_args[0][2]
+    assert variables["id"] == "el_1"
+
+
+# ── Structures ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLibraryStructures:
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_list_library_structures(self, mock_execute, mock_config):
+    mock_execute.return_value = {
+      "libraryStructures": [
+        {
+          "id": "struct_1",
+          "name": "BS-classified",
+          "blockType": "balance_sheet",
+          "taxonomyId": "tax_rsgaap",
+          "roleUri": "https://taxonomy.robosystems.ai/roles/bs",
+          "isActive": True,
+        }
+      ]
+    }
+    client = LibraryClient(mock_config)
+    structures = client.list_library_structures()
+    assert len(structures) == 1
+    assert structures[0].block_type == "balance_sheet"
+    assert structures[0].is_active is True
+    assert mock_execute.call_args[0][0] == LIBRARY_GRAPH_ID
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_list_library_structures_forwards_filters(self, mock_execute, mock_config):
+    mock_execute.return_value = {"libraryStructures": []}
+    client = LibraryClient(mock_config)
+    client.list_library_structures(
+      "kg1a2b3c", taxonomy_id="tax_rsgaap", block_type="income_statement"
+    )
+    assert mock_execute.call_args[0][0] == "kg1a2b3c"
+    variables = mock_execute.call_args[0][2]
+    assert variables["taxonomyId"] == "tax_rsgaap"
+    assert variables["blockType"] == "income_statement"
+
+
+# ── Classifications / Equivalence ──────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLibraryElementClassifications:
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_element_classifications(self, mock_execute, mock_config):
+    mock_execute.return_value = {
+      "libraryElementClassifications": [
+        {
+          "category": "elementsOfFinancialStatements",
+          "identifier": "asset",
+          "name": "Asset",
+          "isPrimary": True,
+        },
+        {
+          "category": "activity",
+          "identifier": "operatingActivity",
+          "name": None,
+          "isPrimary": False,
+        },
+      ]
+    }
+    client = LibraryClient(mock_config)
+    classifications = client.get_library_element_classifications("el_1")
+    assert len(classifications) == 2
+    assert classifications[0].category == "elementsOfFinancialStatements"
+    assert classifications[0].is_primary is True
+    assert classifications[1].name is None
+    variables = mock_execute.call_args[0][2]
+    assert variables["id"] == "el_1"
+
+
+@pytest.mark.unit
+class TestLibraryElementEquivalents:
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_element_equivalents(self, mock_execute, mock_config):
+    peer = {
+      "id": "el_2",
+      "qname": "us-gaap:Cash",
+      "name": "Cash",
+      "trait": "asset",
+      "source": "us-gaap",
+    }
+    mock_execute.return_value = {
+      "libraryElementEquivalents": {
+        "element": {
+          "id": "el_1",
+          "qname": "fac:Cash",
+          "name": "Cash",
+          "trait": "asset",
+          "source": "fac",
+        },
+        "equivalents": [peer],
+      }
+    }
+    client = LibraryClient(mock_config)
+    equivalence = client.get_library_element_equivalents("el_1")
+    assert equivalence is not None
+    assert equivalence.element.qname == "fac:Cash"
+    assert len(equivalence.equivalents) == 1
+    assert equivalence.equivalents[0].source == "us-gaap"
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_library_element_equivalents_returns_none_when_missing(
+    self, mock_execute, mock_config
+  ):
+    mock_execute.return_value = {"libraryElementEquivalents": None}
+    client = LibraryClient(mock_config)
+    assert client.get_library_element_equivalents("el_nope") is None


### PR DESCRIPTION
Closes the remaining pre-1.0 alignment gaps between this client and the TypeScript client, plus two outright bugs in the auth and singleton plumbing.

**Facade + lifecycle**

- `RoboSystemsClients` now wires `LibraryClient` as `clients.library` (it was never imported by the aggregate facade), mirroring the TS `clients/index.ts` exposure.
- The import-time `clients = RoboSystemsClients()` singleton in `robosystems_client/clients/__init__.py` is gone. Importing the package used to instantiate a full client stack bound to `localhost:8000` before the caller could configure anything. It's replaced by a lazy `get_clients()` accessor (module-level `_clients` created on first call), mirroring the TS `getClients()`. This is a deliberate breaking change in the 0.x window — code that did `from robosystems_client.clients import clients` must switch to `get_clients()`. The module-level convenience functions (`execute_query`, `monitor_operation`, …) now route through the lazy accessor.
- The package root now re-exports the public surface: `RoboSystemsClients`, `RoboSystemsClientConfig`, `get_clients`, `LedgerClient`, `InvestorClient`, `LibraryClient`, and `GraphQLError`.

**Auth bug**

`AuthenticatedClients` set BOTH `X-API-Key` and `Authorization: Bearer` to the same credential. Per the backend routing rule (documented in `graphql/client.py`), the copy in the wrong header is guaranteed-invalid: `rfs…` keys only validate as `X-API-Key`, JWTs only as Bearer. Credentials now route to exactly one header by prefix, in both the header dict and the stored `AuthenticatedClient` (which previously Bearer-wrapped the API key). `TokenClients` had the same class of bug for the inverse input and now routes the same way. `CookieAuthClients` was unaffected.

**TS method parity**

- `LedgerClient.compute_metrics` — wires the already-generated `compute-metrics` REST op through `_call_op`/`_typed_result`, with `idempotency_key` support, mirroring TS `computeMetrics`.
- `LedgerClient.get_mapping_candidates(graph_id, classification)` — new typed GraphQL query (`MappingCandidates.graphql`), mirroring the TS query document.
- `LedgerClient.get_information_block` gains keyword-only `scenario_id`, `series`, `series_history`, `series_forecast` options. The `GetInformationBlock` document picks up the same variables plus the selections the TS document has (`view.chart`, row `itemType`, period `forecast`, `factSet.scenarioId`). Unset options are `None`-stripped by the transport, so the document defaults apply and existing calls send exactly what they sent before.
- `LibraryClient.list_library_structures` and `LibraryClient.get_library_element_classifications` — new typed queries matching the TS documents.
- `list_library_taxonomy_arcs` gains the `structure_id` filter; the count field now shares all filters with the page (previously it counted the whole taxonomy regardless of the association-type filter).
- `create_report` default `taxonomy_id` changed from `"tax_usgaap_reporting"` to `"rs-gaap"`, matching the backend's `CreateReportRequest` default and the TS client.

**token_provider**

`RoboSystemsClientConfig` gains `token_provider` — a zero-arg callable returning the current credential, consulted per request by the GraphQL-backed facades (ledger / investor / library, which build fresh clients per call in `_get_client` / `_get_graphql_client`) and taking precedence over the static token. Mirrors the TS `tokenProvider`; `TokenProvider` is exported for typing callbacks, and the resolver docstring points at `TokenManager` for refresh scheduling.

**Housekeeping**

The stale local `dist/` wheels (0.2.x/0.3.x) turned out to be untracked — `dist/` was already in `.gitignore` and nothing under it was ever committed, so there was nothing to `git rm`; the stale local files were deleted.

All generated GraphQL code is regenerated and `just generate-graphql` is idempotent against this branch.

## Test plan

- `just test` — 518 passed, 17 skipped (pandas-optional), including the new `tests/test_library_client.py` covering every `LibraryClient` method (transport-boundary mocks on `GraphQLClient.execute`, variable forwarding, `structure_id` filter, token_provider precedence) and new `LedgerClient` tests for `compute_metrics`, `get_mapping_candidates`, and the `get_information_block` options (unset-strip + full forwarding).
- Existing dual-header assertions in `tests/test_extensions_integration.py` updated to assert single-header routing for both credential shapes.
- `just lint` — ruff 0.16.1 check + format clean.
- `just typecheck` — basedpyright, 0 errors.
- `just generate-graphql` — zero diff after regen (CI drift gate stays green).