### PR TITLE
feat(sdk): document usage limits on GraphLimitsResponse

### DIFF
--- a/robosystems_client/api/connections/sync_connection.py
+++ b/robosystems_client/api/connections/sync_connection.py
@@ -119,8 +119,8 @@ def sync_detailed(
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
-  chart of accounts. Returns an `OperationEnvelope` — monitor progress via SSE at
-  `/v1/operations/{operation_id}/stream`. Supports `Idempotency-Key`.
+  chart of accounts. Async — returns an `OperationEnvelope` with the provider task id; completion is
+  reflected in the connection's `last_sync` timestamp. Supports `Idempotency-Key`.
 
   Args:
       graph_id (str):
@@ -161,8 +161,8 @@ def sync(
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
-  chart of accounts. Returns an `OperationEnvelope` — monitor progress via SSE at
-  `/v1/operations/{operation_id}/stream`. Supports `Idempotency-Key`.
+  chart of accounts. Async — returns an `OperationEnvelope` with the provider task id; completion is
+  reflected in the connection's `last_sync` timestamp. Supports `Idempotency-Key`.
 
   Args:
       graph_id (str):
@@ -198,8 +198,8 @@ async def asyncio_detailed(
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
-  chart of accounts. Returns an `OperationEnvelope` — monitor progress via SSE at
-  `/v1/operations/{operation_id}/stream`. Supports `Idempotency-Key`.
+  chart of accounts. Async — returns an `OperationEnvelope` with the provider task id; completion is
+  reflected in the connection's `last_sync` timestamp. Supports `Idempotency-Key`.
 
   Args:
       graph_id (str):
@@ -238,8 +238,8 @@ async def asyncio(
   """Sync Connection
 
    SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and
-  chart of accounts. Returns an `OperationEnvelope` — monitor progress via SSE at
-  `/v1/operations/{operation_id}/stream`. Supports `Idempotency-Key`.
+  chart of accounts. Async — returns an `OperationEnvelope` with the provider task id; completion is
+  reflected in the connection's `last_sync` timestamp. Supports `Idempotency-Key`.
 
   Args:
       graph_id (str):

--- a/robosystems_client/api/graph_limits/get_graph_limits.py
+++ b/robosystems_client/api/graph_limits/get_graph_limits.py
@@ -94,7 +94,7 @@ def sync_detailed(
   """Get Graph Operational Limits
 
    Limits vary by subscription tier (ladybug-standard, ladybug-large, ladybug-xlarge). Includes
-  storage, query, backup, rate, credit, and instance usage limits.
+  storage, query, backup, rate, credit, document, and instance usage limits.
 
   Args:
       graph_id (str):
@@ -126,7 +126,7 @@ def sync(
   """Get Graph Operational Limits
 
    Limits vary by subscription tier (ladybug-standard, ladybug-large, ladybug-xlarge). Includes
-  storage, query, backup, rate, credit, and instance usage limits.
+  storage, query, backup, rate, credit, document, and instance usage limits.
 
   Args:
       graph_id (str):
@@ -153,7 +153,7 @@ async def asyncio_detailed(
   """Get Graph Operational Limits
 
    Limits vary by subscription tier (ladybug-standard, ladybug-large, ladybug-xlarge). Includes
-  storage, query, backup, rate, credit, and instance usage limits.
+  storage, query, backup, rate, credit, document, and instance usage limits.
 
   Args:
       graph_id (str):
@@ -183,7 +183,7 @@ async def asyncio(
   """Get Graph Operational Limits
 
    Limits vary by subscription tier (ladybug-standard, ladybug-large, ladybug-xlarge). Includes
-  storage, query, backup, rate, credit, and instance usage limits.
+  storage, query, backup, rate, credit, document, and instance usage limits.
 
   Args:
       graph_id (str):

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -186,6 +186,7 @@ from .detailed_transactions_response_summary import DetailedTransactionsResponse
 from .dimension import Dimension
 from .dimension_type import DimensionType
 from .document_detail_response import DocumentDetailResponse
+from .document_limits import DocumentLimits
 from .document_list_item import DocumentListItem
 from .document_list_response import DocumentListResponse
 from .document_section import DocumentSection
@@ -1006,6 +1007,7 @@ __all__ = (
   "Dimension",
   "DimensionType",
   "DocumentDetailResponse",
+  "DocumentLimits",
   "DocumentListItem",
   "DocumentListResponse",
   "DocumentSection",

--- a/robosystems_client/models/document_limits.py
+++ b/robosystems_client/models/document_limits.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="DocumentLimits")
+
+
+@_attrs_define
+class DocumentLimits:
+  """Knowledge-base document usage against the tier's cap.
+
+  Attributes:
+      current_count (int): Uploaded documents currently stored for this graph
+      approaching_limit (bool): Whether approaching document limit (>80%)
+      max_documents (int | None | Unset): Maximum uploaded documents for this tier (null when uncapped)
+  """
+
+  current_count: int
+  approaching_limit: bool
+  max_documents: int | None | Unset = UNSET
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    current_count = self.current_count
+
+    approaching_limit = self.approaching_limit
+
+    max_documents: int | None | Unset
+    if isinstance(self.max_documents, Unset):
+      max_documents = UNSET
+    else:
+      max_documents = self.max_documents
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+    field_dict.update(
+      {
+        "current_count": current_count,
+        "approaching_limit": approaching_limit,
+      }
+    )
+    if max_documents is not UNSET:
+      field_dict["max_documents"] = max_documents
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    current_count = d.pop("current_count")
+
+    approaching_limit = d.pop("approaching_limit")
+
+    def _parse_max_documents(data: object) -> int | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(int | None | Unset, data)
+
+    max_documents = _parse_max_documents(d.pop("max_documents", UNSET))
+
+    document_limits = cls(
+      current_count=current_count,
+      approaching_limit=approaching_limit,
+      max_documents=max_documents,
+    )
+
+    document_limits.additional_properties = d
+    return document_limits
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties

--- a/robosystems_client/models/graph_limits_response.py
+++ b/robosystems_client/models/graph_limits_response.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
   from ..models.content_limits import ContentLimits
   from ..models.copy_operation_limits import CopyOperationLimits
   from ..models.credit_limits import CreditLimits
+  from ..models.document_limits import DocumentLimits
   from ..models.instance_usage import InstanceUsage
   from ..models.query_limits import QueryLimits
   from ..models.rate_limits import RateLimits
@@ -37,6 +38,7 @@ class GraphLimitsResponse:
       backups (BackupLimits): Backup operation limits.
       rate_limits (RateLimits): API rate limits.
       credits_ (CreditLimits | None | Unset): AI credit limits (if applicable)
+      documents (DocumentLimits | None | Unset): Knowledge-base document usage and tier cap (user graphs only)
       content (ContentLimits | None | Unset): Per-operation materialization limits (if applicable)
       instance (InstanceUsage | None | Unset): Aggregate instance storage usage (user graphs only)
   """
@@ -51,6 +53,7 @@ class GraphLimitsResponse:
   backups: BackupLimits
   rate_limits: RateLimits
   credits_: CreditLimits | None | Unset = UNSET
+  documents: DocumentLimits | None | Unset = UNSET
   content: ContentLimits | None | Unset = UNSET
   instance: InstanceUsage | None | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -58,6 +61,7 @@ class GraphLimitsResponse:
   def to_dict(self) -> dict[str, Any]:
     from ..models.content_limits import ContentLimits
     from ..models.credit_limits import CreditLimits
+    from ..models.document_limits import DocumentLimits
     from ..models.instance_usage import InstanceUsage
 
     graph_id = self.graph_id
@@ -85,6 +89,14 @@ class GraphLimitsResponse:
       credits_ = self.credits_.to_dict()
     else:
       credits_ = self.credits_
+
+    documents: dict[str, Any] | None | Unset
+    if isinstance(self.documents, Unset):
+      documents = UNSET
+    elif isinstance(self.documents, DocumentLimits):
+      documents = self.documents.to_dict()
+    else:
+      documents = self.documents
 
     content: dict[str, Any] | None | Unset
     if isinstance(self.content, Unset):
@@ -119,6 +131,8 @@ class GraphLimitsResponse:
     )
     if credits_ is not UNSET:
       field_dict["credits"] = credits_
+    if documents is not UNSET:
+      field_dict["documents"] = documents
     if content is not UNSET:
       field_dict["content"] = content
     if instance is not UNSET:
@@ -132,6 +146,7 @@ class GraphLimitsResponse:
     from ..models.content_limits import ContentLimits
     from ..models.copy_operation_limits import CopyOperationLimits
     from ..models.credit_limits import CreditLimits
+    from ..models.document_limits import DocumentLimits
     from ..models.instance_usage import InstanceUsage
     from ..models.query_limits import QueryLimits
     from ..models.rate_limits import RateLimits
@@ -172,6 +187,23 @@ class GraphLimitsResponse:
       return cast(CreditLimits | None | Unset, data)
 
     credits_ = _parse_credits_(d.pop("credits", UNSET))
+
+    def _parse_documents(data: object) -> DocumentLimits | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        documents_type_0 = DocumentLimits.from_dict(data)
+
+        return documents_type_0
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(DocumentLimits | None | Unset, data)
+
+    documents = _parse_documents(d.pop("documents", UNSET))
 
     def _parse_content(data: object) -> ContentLimits | None | Unset:
       if data is None:
@@ -218,6 +250,7 @@ class GraphLimitsResponse:
       backups=backups,
       rate_limits=rate_limits,
       credits_=credits_,
+      documents=documents,
       content=content,
       instance=instance,
     )


### PR DESCRIPTION
## Summary

Regenerates the SDK against the backend's new `documents` section on `GET /v1/graphs/{graph_id}/limits` (RoboFinSystems/robosystems#1056): a `DocumentLimits` model (`current_count`, `max_documents`, `approaching_limit`) surfaced as an optional `documents` field on `GraphLimitsResponse`.

Strictly additive to the public surface — rides as a **minor** under the 1.0 contract.

## Changes

- **`robosystems_client/models/document_limits.py`** — new generated `DocumentLimits` model.
- **`robosystems_client/models/graph_limits_response.py`, `models/__init__.py`** — optional `documents` field wired in and exported.
- **`api/graph_limits/get_graph_limits.py`** — endpoint description string updated by the generator.
- **`api/connections/sync_connection.py`** — docstring-only drift catch-up from an earlier backend description change (sync now described as async with `last_sync` completion, not SSE monitoring); no signature changes.

Generated with `just generate-sdk` against a backend running the paired branch; `schema.graphql` snapshot unchanged (no GraphQL surface change).

## Testing

- `just test-all` — ruff check, format check, basedpyright, and 535 tests all pass (pre-push hook re-ran the full gate).

## Notes / Follow-ups

- Publish as a minor once the backend PR merges; pairs with robosystems-typescript-client#175.
