### PR TITLE
feat(client): regenerate for graph-scoped API keys

### DIFF
--- a/robosystems_client/api/backup/get_backup_download_url.py
+++ b/robosystems_client/api/backup/get_backup_download_url.py
@@ -87,7 +87,11 @@ def sync_detailed(
 ) -> Response[Any | BackupDownloadUrlResponse | HTTPValidationError]:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted, compressed .lbug files only)
+   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
+  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
+  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
+  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
+  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):
@@ -124,7 +128,11 @@ def sync(
 ) -> Any | BackupDownloadUrlResponse | HTTPValidationError | None:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted, compressed .lbug files only)
+   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
+  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
+  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
+  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
+  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):
@@ -156,7 +164,11 @@ async def asyncio_detailed(
 ) -> Response[Any | BackupDownloadUrlResponse | HTTPValidationError]:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted, compressed .lbug files only)
+   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
+  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
+  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
+  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
+  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):
@@ -191,7 +203,11 @@ async def asyncio(
 ) -> Any | BackupDownloadUrlResponse | HTTPValidationError | None:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted, compressed .lbug files only)
+   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
+  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
+  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
+  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
+  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):

--- a/robosystems_client/models/api_key_info.py
+++ b/robosystems_client/models/api_key_info.py
@@ -24,6 +24,7 @@ class APIKeyInfo:
       description (None | str | Unset): API key description
       last_used_at (None | str | Unset): Last used timestamp
       expires_at (None | str | Unset): Expiration timestamp
+      graph_id (None | str | Unset): Graph scope; null means account-wide
   """
 
   id: str
@@ -34,6 +35,7 @@ class APIKeyInfo:
   description: None | str | Unset = UNSET
   last_used_at: None | str | Unset = UNSET
   expires_at: None | str | Unset = UNSET
+  graph_id: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -65,6 +67,12 @@ class APIKeyInfo:
     else:
       expires_at = self.expires_at
 
+    graph_id: None | str | Unset
+    if isinstance(self.graph_id, Unset):
+      graph_id = UNSET
+    else:
+      graph_id = self.graph_id
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -82,6 +90,8 @@ class APIKeyInfo:
       field_dict["last_used_at"] = last_used_at
     if expires_at is not UNSET:
       field_dict["expires_at"] = expires_at
+    if graph_id is not UNSET:
+      field_dict["graph_id"] = graph_id
 
     return field_dict
 
@@ -125,6 +135,15 @@ class APIKeyInfo:
 
     expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
 
+    def _parse_graph_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    graph_id = _parse_graph_id(d.pop("graph_id", UNSET))
+
     api_key_info = cls(
       id=id,
       name=name,
@@ -134,6 +153,7 @@ class APIKeyInfo:
       description=description,
       last_used_at=last_used_at,
       expires_at=expires_at,
+      graph_id=graph_id,
     )
 
     api_key_info.additional_properties = d

--- a/robosystems_client/models/backup_response.py
+++ b/robosystems_client/models/backup_response.py
@@ -6,6 +6,8 @@ from typing import Any, TypeVar, cast
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 T = TypeVar("T", bound="BackupResponse")
 
 
@@ -31,6 +33,9 @@ class BackupResponse:
       created_at (str):
       completed_at (None | str):
       expires_at (None | str):
+      download_extension (None | str | Unset): Extension the download will carry, and therefore how to unpack it:
+          '.lbug.zip' is a ZIP holding the LadybugDB database file, '.lbug.zst' is zstd-compressed (`zstd -d`). Null when
+          the backup is encrypted and so cannot be downloaded.
   """
 
   backup_id: str
@@ -50,6 +55,7 @@ class BackupResponse:
   created_at: str
   completed_at: None | str
   expires_at: None | str
+  download_extension: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -89,6 +95,12 @@ class BackupResponse:
     expires_at: None | str
     expires_at = self.expires_at
 
+    download_extension: None | str | Unset
+    if isinstance(self.download_extension, Unset):
+      download_extension = UNSET
+    else:
+      download_extension = self.download_extension
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -112,6 +124,8 @@ class BackupResponse:
         "expires_at": expires_at,
       }
     )
+    if download_extension is not UNSET:
+      field_dict["download_extension"] = download_extension
 
     return field_dict
 
@@ -162,6 +176,15 @@ class BackupResponse:
 
     expires_at = _parse_expires_at(d.pop("expires_at"))
 
+    def _parse_download_extension(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    download_extension = _parse_download_extension(d.pop("download_extension", UNSET))
+
     backup_response = cls(
       backup_id=backup_id,
       graph_id=graph_id,
@@ -180,6 +203,7 @@ class BackupResponse:
       created_at=created_at,
       completed_at=completed_at,
       expires_at=expires_at,
+      download_extension=download_extension,
     )
 
     backup_response.additional_properties = d

--- a/robosystems_client/models/create_api_key_request.py
+++ b/robosystems_client/models/create_api_key_request.py
@@ -19,11 +19,14 @@ class CreateAPIKeyRequest:
       name (str): Name for the API key
       description (None | str | Unset): Optional description
       expires_at (None | str | Unset): Optional expiration date in ISO format (e.g. 2024-12-31T23:59:59Z)
+      graph_id (None | str | Unset): Optional graph scope. A scoped key works only for this graph (and its subgraphs)
+          and is the only kind of key accepted in an MCP connector URL. Omit for an account-wide key.
   """
 
   name: str
   description: None | str | Unset = UNSET
   expires_at: None | str | Unset = UNSET
+  graph_id: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -41,6 +44,12 @@ class CreateAPIKeyRequest:
     else:
       expires_at = self.expires_at
 
+    graph_id: None | str | Unset
+    if isinstance(self.graph_id, Unset):
+      graph_id = UNSET
+    else:
+      graph_id = self.graph_id
+
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
     field_dict.update(
@@ -52,6 +61,8 @@ class CreateAPIKeyRequest:
       field_dict["description"] = description
     if expires_at is not UNSET:
       field_dict["expires_at"] = expires_at
+    if graph_id is not UNSET:
+      field_dict["graph_id"] = graph_id
 
     return field_dict
 
@@ -78,10 +89,20 @@ class CreateAPIKeyRequest:
 
     expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
 
+    def _parse_graph_id(data: object) -> None | str | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(None | str | Unset, data)
+
+    graph_id = _parse_graph_id(d.pop("graph_id", UNSET))
+
     create_api_key_request = cls(
       name=name,
       description=description,
       expires_at=expires_at,
+      graph_id=graph_id,
     )
 
     create_api_key_request.additional_properties = d


### PR DESCRIPTION
## Summary

Client regeneration against the updated OpenAPI spec. Additive only — rides a minor under the 1.x contract:

- `APIKeyInfo.graph_id` and `CreateAPIKeyRequest.graph_id` — optional graph scope for API keys (pairs with [robosystems#1064](https://github.com/RoboFinSystems/robosystems/pull/1064); merge that first)
- `BackupResponse.download_extension` + updated backup-download docstring — catching up with the self-describing backup format already on main

## Testing

- `just test-all` green: 518 passed, lint + typecheck clean