### PR TITLE
Fix the missed reconciling-item rename; surface obligation detail

### DIFF
--- a/robosystems_client/graphql/generated/__init__.py
+++ b/robosystems_client/graphql/generated/__init__.py
@@ -75,7 +75,9 @@ from .get_ledger_event_block import GetLedgerEventBlock, GetLedgerEventBlockEven
 from .get_ledger_fiscal_calendar import (
   GetLedgerFiscalCalendar,
   GetLedgerFiscalCalendarFiscalCalendar,
+  GetLedgerFiscalCalendarFiscalCalendarPendingObligationSample,
   GetLedgerFiscalCalendarFiscalCalendarPeriods,
+  GetLedgerFiscalCalendarFiscalCalendarStrandedObligationSample,
 )
 from .get_ledger_mapped_trial_balance import (
   GetLedgerMappedTrialBalance,
@@ -455,7 +457,9 @@ __all__ = [
   "GetLedgerEventBlockEventBlock",
   "GetLedgerFiscalCalendar",
   "GetLedgerFiscalCalendarFiscalCalendar",
+  "GetLedgerFiscalCalendarFiscalCalendarPendingObligationSample",
   "GetLedgerFiscalCalendarFiscalCalendarPeriods",
+  "GetLedgerFiscalCalendarFiscalCalendarStrandedObligationSample",
   "GetLedgerMappedTrialBalance",
   "GetLedgerMappedTrialBalanceMappedTrialBalance",
   "GetLedgerMappedTrialBalanceMappedTrialBalanceRows",

--- a/robosystems_client/graphql/generated/get_ledger_fiscal_calendar.py
+++ b/robosystems_client/graphql/generated/get_ledger_fiscal_calendar.py
@@ -20,10 +20,34 @@ class GetLedgerFiscalCalendarFiscalCalendar(BaseModel):
   catch_up_sequence: list[str] = Field(alias="catchUpSequence")
   closeable_now: bool = Field(alias="closeableNow")
   blockers: list[str]
+  pending_obligation_count: int = Field(alias="pendingObligationCount")
+  pending_obligation_sample: list[
+    "GetLedgerFiscalCalendarFiscalCalendarPendingObligationSample"
+  ] = Field(alias="pendingObligationSample")
+  earliest_pending_period: Optional[str] = Field(alias="earliestPendingPeriod")
+  stranded_obligation_count: int = Field(alias="strandedObligationCount")
+  stranded_obligation_sample: list[
+    "GetLedgerFiscalCalendarFiscalCalendarStrandedObligationSample"
+  ] = Field(alias="strandedObligationSample")
+  sync_stale_days: Optional[int] = Field(alias="syncStaleDays")
   last_close_at: Optional[str] = Field(alias="lastCloseAt")
   initialized_at: Optional[str] = Field(alias="initializedAt")
   last_sync_at: Optional[str] = Field(alias="lastSyncAt")
   periods: list["GetLedgerFiscalCalendarFiscalCalendarPeriods"]
+
+
+class GetLedgerFiscalCalendarFiscalCalendarPendingObligationSample(BaseModel):
+  event_id: str = Field(alias="eventId")
+  schedule_id: Optional[str] = Field(alias="scheduleId")
+  schedule_name: Optional[str] = Field(alias="scheduleName")
+  period: str
+
+
+class GetLedgerFiscalCalendarFiscalCalendarStrandedObligationSample(BaseModel):
+  event_id: str = Field(alias="eventId")
+  schedule_id: Optional[str] = Field(alias="scheduleId")
+  schedule_name: Optional[str] = Field(alias="scheduleName")
+  period: str
 
 
 class GetLedgerFiscalCalendarFiscalCalendarPeriods(BaseModel):

--- a/robosystems_client/graphql/generated/operations.py
+++ b/robosystems_client/graphql/generated/operations.py
@@ -633,6 +633,22 @@ query GetLedgerFiscalCalendar {
     catchUpSequence
     closeableNow
     blockers
+    pendingObligationCount
+    pendingObligationSample {
+      eventId
+      scheduleId
+      scheduleName
+      period
+    }
+    earliestPendingPeriod
+    strandedObligationCount
+    strandedObligationSample {
+      eventId
+      scheduleId
+      scheduleName
+      period
+    }
+    syncStaleDays
     lastCloseAt
     initializedAt
     lastSyncAt

--- a/robosystems_client/graphql/operations/ledger/GetLedgerFiscalCalendar.graphql
+++ b/robosystems_client/graphql/operations/ledger/GetLedgerFiscalCalendar.graphql
@@ -2,6 +2,12 @@ query GetLedgerFiscalCalendar {
   fiscalCalendar {
     graphId fiscalYearStartMonth closedThrough closeTarget
     gapPeriods catchUpSequence closeableNow blockers
+    pendingObligationCount
+    pendingObligationSample { eventId scheduleId scheduleName period }
+    earliestPendingPeriod
+    strandedObligationCount
+    strandedObligationSample { eventId scheduleId scheduleName period }
+    syncStaleDays
     lastCloseAt initializedAt lastSyncAt
     periods { name startDate endDate status closedAt }
   }

--- a/robosystems_client/graphql/schema.graphql
+++ b/robosystems_client/graphql/schema.graphql
@@ -15,7 +15,7 @@ type Query {
   openReceivablesByAgent: [OpenBalanceByAgent!]!
   openPayablesByAgent: [OpenBalanceByAgent!]!
   eventBlock(id: String!): EventBlock
-  eventBlocks(eventType: String = null, eventCategory: String = null, status: String = null, agentId: String = null, source: String = null, payloadDrift: Boolean = null, limit: Int = null, offset: Int = null): [EventBlock!]!
+  eventBlocks(eventType: String = null, eventCategory: String = null, status: String = null, agentId: String = null, source: String = null, isReconcilingItem: Boolean = null, limit: Int = null, offset: Int = null): [EventBlock!]!
   summary: LedgerSummary
   accounts(classification: String = null, isActive: Boolean = null, limit: Int = null, offset: Int = null): AccountList
   accountTree(includeInactive: Boolean = null): AccountTree
@@ -636,7 +636,7 @@ type EventBlock {
   currency: String!
   description: String
   metadata: JSON!
-  payloadDrift: Boolean!
+  isReconcilingItem: Boolean!
   dimensionIds: [String!]!
   agentId: String
   resourceType: String

--- a/robosystems_client/models/event_block_envelope.py
+++ b/robosystems_client/models/event_block_envelope.py
@@ -57,10 +57,12 @@ class EventBlockEnvelope:
           amount (int | None | Unset): Economic value in **cents** of `currency`, signed (inflows positive, outflows
               negative). `null` for non-economic events.
           description (None | str | Unset): Free-text human-readable summary.
-          payload_drift (bool | Unset): True when a source re-sync surfaced a changed upstream payload for an event whose
-              GL is already posted (committed/fulfilled are immutable to sync). The live payload and GL are untouched; the
-              incoming payload is stashed in `metadata.drift_payload` with `metadata.drift_detected_at`. Drifted events need
-              operator reconciliation — the local books no longer mirror the source. Default: False.
+          is_reconciling_item (bool | Unset): True when this event is a reconciling item: a source re-sync surfaced a
+              changed upstream payload for an event whose GL is already posted (committed/fulfilled are immutable to sync) —
+              the local books legitimately no longer mirror the source, and the difference awaits an explicit disposition
+              (restate the affected months, or book a catch-up entry in the open period). The live payload and GL are
+              untouched; the incoming payload is stashed in `metadata.drift_payload` with `metadata.drift_detected_at`.
+              Default: False.
           event_action (EventBlockEnvelopeEventActionType0 | None | Unset): Canonical action verb refining
               `event_category`. Null when the source adapter or capture path didn't supply one.
           agent_id (None | str | Unset): Counterparty agent ID, when the event involves one.
@@ -94,7 +96,7 @@ class EventBlockEnvelope:
   external_url: None | str | Unset = UNSET
   amount: int | None | Unset = UNSET
   description: None | str | Unset = UNSET
-  payload_drift: bool | Unset = False
+  is_reconciling_item: bool | Unset = False
   event_action: EventBlockEnvelopeEventActionType0 | None | Unset = UNSET
   agent_id: None | str | Unset = UNSET
   resource_type: None | str | Unset = UNSET
@@ -162,7 +164,7 @@ class EventBlockEnvelope:
     else:
       description = self.description
 
-    payload_drift = self.payload_drift
+    is_reconciling_item = self.is_reconciling_item
 
     event_action: None | str | Unset
     if isinstance(self.event_action, Unset):
@@ -242,8 +244,8 @@ class EventBlockEnvelope:
       field_dict["amount"] = amount
     if description is not UNSET:
       field_dict["description"] = description
-    if payload_drift is not UNSET:
-      field_dict["payload_drift"] = payload_drift
+    if is_reconciling_item is not UNSET:
+      field_dict["is_reconciling_item"] = is_reconciling_item
     if event_action is not UNSET:
       field_dict["event_action"] = event_action
     if agent_id is not UNSET:
@@ -345,7 +347,7 @@ class EventBlockEnvelope:
 
     description = _parse_description(d.pop("description", UNSET))
 
-    payload_drift = d.pop("payload_drift", UNSET)
+    is_reconciling_item = d.pop("is_reconciling_item", UNSET)
 
     def _parse_event_action(
       data: object,
@@ -455,7 +457,7 @@ class EventBlockEnvelope:
       external_url=external_url,
       amount=amount,
       description=description,
-      payload_drift=payload_drift,
+      is_reconciling_item=is_reconciling_item,
       event_action=event_action,
       agent_id=agent_id,
       resource_type=resource_type,

--- a/tests/test_ledger_client.py
+++ b/tests/test_ledger_client.py
@@ -253,6 +253,12 @@ class TestLedgerReads:
         "catchUpSequence": [],
         "closeableNow": True,
         "blockers": [],
+        "pendingObligationCount": 0,
+        "pendingObligationSample": [],
+        "earliestPendingPeriod": None,
+        "strandedObligationCount": 0,
+        "strandedObligationSample": [],
+        "syncStaleDays": None,
         "lastCloseAt": None,
         "initializedAt": "2026-01-01T00:00:00Z",
         "lastSyncAt": None,
@@ -265,6 +271,54 @@ class TestLedgerReads:
     assert cal.closed_through == "2026-02"
     assert cal.closeable_now is True
     assert cal.fiscal_year_start_month == 1
+    assert cal.stranded_obligation_count == 0
+
+  @patch("robosystems_client.graphql.client.GraphQLClient.execute")
+  def test_get_fiscal_calendar_names_blocking_obligations(
+    self, mock_execute, mock_config, graph_id
+  ):
+    """A blocked calendar carries the detail needed to act on the blocker.
+
+    `blockers` alone says a close is held but not by what; the sample names
+    the schedule so a caller can promote or void it without a second query.
+    """
+    mock_execute.return_value = {
+      "fiscalCalendar": {
+        "graphId": graph_id,
+        "fiscalYearStartMonth": 1,
+        "closedThrough": "2026-02",
+        "closeTarget": "2026-03",
+        "gapPeriods": 1,
+        "catchUpSequence": ["2026-03"],
+        "closeableNow": False,
+        "blockers": ["stranded_obligations"],
+        "pendingObligationCount": 0,
+        "pendingObligationSample": [],
+        "earliestPendingPeriod": None,
+        "strandedObligationCount": 2,
+        "strandedObligationSample": [
+          {
+            "eventId": "evt_1",
+            "scheduleId": "str_prepaid",
+            "scheduleName": "Prepaid Insurance",
+            "period": "2026-03",
+          }
+        ],
+        "syncStaleDays": None,
+        "lastCloseAt": None,
+        "initializedAt": "2026-01-01T00:00:00Z",
+        "lastSyncAt": None,
+        "periods": [],
+      }
+    }
+    client = LedgerClient(mock_config)
+    cal = client.get_fiscal_calendar(graph_id)
+    assert cal is not None
+    assert cal.closeable_now is False
+    assert cal.blockers == ["stranded_obligations"]
+    assert cal.stranded_obligation_count == 2
+    assert cal.stranded_obligation_sample[0].schedule_name == "Prepaid Insurance"
+    assert cal.stranded_obligation_sample[0].period == "2026-03"
 
 
 # ── Writes (Operation envelope) ────────────────────────────────────────


### PR DESCRIPTION
Regenerated against `main` with RoboFinSystems/robosystems#1072 in it.

## The rename 1.3.0 missed

1.3.0 shipped `payload_drift` on `EventBlockEnvelope` — the name #1072 retired — **27 minutes after** the rename merged to `main`. The cause isn't a race, it's a property of how this SDK is built: **generation reads whatever the local stack is serving, not `main`.** The stack was running a branch cut before #1072 landed, and restarting it faithfully rebuilt that branch. Merging upstream changed nothing about what the container served.

Corrected here on `EventBlockEnvelope` and in the `schema.graphql` snapshot.

**Not a break.** The rename touches generated internals only — no facade signature or documented model exposed the field, so no consumer code changes. Per the versioning policy that makes this additive: a minor.

The lesson worth keeping: `git log origin/main ^HEAD` before generating. A restarted stack reads as "current" while being current only with your own branch.

## Obligation detail on the fiscal calendar

`GetLedgerFiscalCalendar` now selects what the API has carried since RoboFinSystems/robosystems#1071 but no client could reach.

`blockers` told a caller a close was held; it could not say by what. A close blocked on `stranded_obligations` — matured obligations that were promoted but never drafted, so closing would silently omit those adjusting entries — surfaced as a bare code with no way to find the schedules responsible.

Added: `pendingObligationCount` / `strandedObligationCount`, their up-to-5 samples (`eventId`, `scheduleId`, `scheduleName`, `period`), `earliestPendingPeriod`, and `syncStaleDays`.

Selected unconditionally rather than behind a second query — the resolver returns `0` / `[]` / `null` when the blocker is inactive, so it costs nothing in the common case and saves a round trip in the case that matters.

## Drift gate

`generated/` regenerated with `just generate-graphql` and committed, so the CI gate that re-derives models from `schema.graphql` + `operations/*.graphql` stays clean.

The existing fiscal-calendar test fixture needed the six new required fields; added alongside it is a case for a *blocked* calendar carrying a named stranded obligation — the shape the fields exist for, which the passing fixture didn't cover.

## Verification

`just test-all` green — 519 passed, 17 skipped; ruff check + format clean; basedpyright 0 errors.