### PR TITLE
feat(client): regenerate for subgraph size_bytes and storage item types

### DIFF
--- a/robosystems_client/models/instance_usage.py
+++ b/robosystems_client/models/instance_usage.py
@@ -28,10 +28,13 @@ class InstanceUsage:
           status (str): Instance status: 'healthy' (<80%), 'approaching' (80-100%), 'over_limit' (>100%)
           node_count (int | None | Unset): Current node count (informational, no limit enforced)
           total_storage_gb (float | None | Unset): Total storage used across all databases in GB
-          usage_percentage (float | None | Unset): Storage usage as percentage of limit (e.g. 105.2)
+          usage_percentage (float | None | Unset): Storage usage as percentage of limit (e.g. 105.2). Derived from the
+              enforced figure — durable bytes only, excluding `transient` build artifacts — so it can read lower than
+              total_storage_gb/limit_gb while a blue-green rebuild is in flight.
           databases (list[DatabaseStorageEntry] | Unset): Per-database storage breakdown
-          items (list[StorageItem] | Unset): Itemized storage by type — graph, memory, subgraph, vectors, staging. Sums to
-              total_storage_gb.
+          items (list[StorageItem] | Unset): Itemized storage by type — graph, memory, subgraph, vectors, staging,
+              transient, orphan. Sums to total_storage_gb. Only `subgraph` items correspond to live subgraphs, so this is the
+              type to sum when reconciling against the subgraph list.
   """
 
   limit_gb: float

--- a/robosystems_client/models/list_subgraphs_response.py
+++ b/robosystems_client/models/list_subgraphs_response.py
@@ -27,6 +27,7 @@ class ListSubgraphsResponse:
       subgraph_count (int): Total number of subgraphs
       subgraphs (list[SubgraphSummary]): List of subgraphs
       max_subgraphs (int | None | Unset): Maximum allowed subgraphs for this tier (None = unlimited)
+      total_size_bytes (int | None | Unset): Combined on-disk footprint of all subgraphs in bytes
       total_size_mb (float | None | Unset): Combined size of all subgraphs in megabytes
   """
 
@@ -37,6 +38,7 @@ class ListSubgraphsResponse:
   subgraph_count: int
   subgraphs: list[SubgraphSummary]
   max_subgraphs: int | None | Unset = UNSET
+  total_size_bytes: int | None | Unset = UNSET
   total_size_mb: float | None | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -62,6 +64,12 @@ class ListSubgraphsResponse:
     else:
       max_subgraphs = self.max_subgraphs
 
+    total_size_bytes: int | None | Unset
+    if isinstance(self.total_size_bytes, Unset):
+      total_size_bytes = UNSET
+    else:
+      total_size_bytes = self.total_size_bytes
+
     total_size_mb: float | None | Unset
     if isinstance(self.total_size_mb, Unset):
       total_size_mb = UNSET
@@ -82,6 +90,8 @@ class ListSubgraphsResponse:
     )
     if max_subgraphs is not UNSET:
       field_dict["max_subgraphs"] = max_subgraphs
+    if total_size_bytes is not UNSET:
+      field_dict["total_size_bytes"] = total_size_bytes
     if total_size_mb is not UNSET:
       field_dict["total_size_mb"] = total_size_mb
 
@@ -118,6 +128,15 @@ class ListSubgraphsResponse:
 
     max_subgraphs = _parse_max_subgraphs(d.pop("max_subgraphs", UNSET))
 
+    def _parse_total_size_bytes(data: object) -> int | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(int | None | Unset, data)
+
+    total_size_bytes = _parse_total_size_bytes(d.pop("total_size_bytes", UNSET))
+
     def _parse_total_size_mb(data: object) -> float | None | Unset:
       if data is None:
         return data
@@ -135,6 +154,7 @@ class ListSubgraphsResponse:
       subgraph_count=subgraph_count,
       subgraphs=subgraphs,
       max_subgraphs=max_subgraphs,
+      total_size_bytes=total_size_bytes,
       total_size_mb=total_size_mb,
     )
 

--- a/robosystems_client/models/storage_item.py
+++ b/robosystems_client/models/storage_item.py
@@ -14,7 +14,9 @@ class StorageItem:
   """One itemized piece of a graph's on-disk footprint.
 
   Attributes:
-      type_ (str): One of: graph, memory, subgraph, vectors, staging
+      type_ (str): One of: graph, memory, subgraph, vectors, staging, transient (blue-green build artifact), orphan (a
+          `{parent}_*` database, vector index, or staging file with no row in the graph registry — reclaimable leftover of
+          a deleted subgraph)
       id (str): Database or index identifier
       bytes_ (int): Size in bytes
   """

--- a/robosystems_client/models/subgraph_response.py
+++ b/robosystems_client/models/subgraph_response.py
@@ -32,6 +32,8 @@ class SubgraphResponse:
       created_at (datetime.datetime): When the subgraph was created
       updated_at (datetime.datetime): When the subgraph was last updated
       description (None | str | Unset): Description of the subgraph's purpose
+      size_bytes (int | None | Unset): On-disk footprint in bytes — the database, its write-ahead log, and its vector
+          index. Prefer this over size_mb at subgraph scale.
       size_mb (float | None | Unset): Size of the subgraph database in megabytes
       node_count (int | None | Unset): Number of nodes in the subgraph
       edge_count (int | None | Unset): Number of edges in the subgraph
@@ -49,6 +51,7 @@ class SubgraphResponse:
   created_at: datetime.datetime
   updated_at: datetime.datetime
   description: None | str | Unset = UNSET
+  size_bytes: int | None | Unset = UNSET
   size_mb: float | None | Unset = UNSET
   node_count: int | None | Unset = UNSET
   edge_count: int | None | Unset = UNSET
@@ -82,6 +85,12 @@ class SubgraphResponse:
       description = UNSET
     else:
       description = self.description
+
+    size_bytes: int | None | Unset
+    if isinstance(self.size_bytes, Unset):
+      size_bytes = UNSET
+    else:
+      size_bytes = self.size_bytes
 
     size_mb: float | None | Unset
     if isinstance(self.size_mb, Unset):
@@ -134,6 +143,8 @@ class SubgraphResponse:
     )
     if description is not UNSET:
       field_dict["description"] = description
+    if size_bytes is not UNSET:
+      field_dict["size_bytes"] = size_bytes
     if size_mb is not UNSET:
       field_dict["size_mb"] = size_mb
     if node_count is not UNSET:
@@ -178,6 +189,15 @@ class SubgraphResponse:
       return cast(None | str | Unset, data)
 
     description = _parse_description(d.pop("description", UNSET))
+
+    def _parse_size_bytes(data: object) -> int | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(int | None | Unset, data)
+
+    size_bytes = _parse_size_bytes(d.pop("size_bytes", UNSET))
 
     def _parse_size_mb(data: object) -> float | None | Unset:
       if data is None:
@@ -251,6 +271,7 @@ class SubgraphResponse:
       created_at=created_at,
       updated_at=updated_at,
       description=description,
+      size_bytes=size_bytes,
       size_mb=size_mb,
       node_count=node_count,
       edge_count=edge_count,

--- a/robosystems_client/models/subgraph_summary.py
+++ b/robosystems_client/models/subgraph_summary.py
@@ -24,7 +24,10 @@ class SubgraphSummary:
       subgraph_type (SubgraphType): Types of subgraphs.
       status (str): Current status
       created_at (datetime.datetime): Creation timestamp
-      size_mb (float | None | Unset): Size in megabytes
+      size_bytes (int | None | Unset): On-disk footprint in bytes — the database, its write-ahead log, and its vector
+          index. Prefer this over size_mb at subgraph scale.
+      size_mb (float | None | Unset): Same footprint in megabytes. Derived from size_bytes; kept for callers that
+          render MB directly.
       last_accessed (datetime.datetime | None | Unset): Last access timestamp
   """
 
@@ -34,6 +37,7 @@ class SubgraphSummary:
   subgraph_type: SubgraphType
   status: str
   created_at: datetime.datetime
+  size_bytes: int | None | Unset = UNSET
   size_mb: float | None | Unset = UNSET
   last_accessed: datetime.datetime | None | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -50,6 +54,12 @@ class SubgraphSummary:
     status = self.status
 
     created_at = self.created_at.isoformat()
+
+    size_bytes: int | None | Unset
+    if isinstance(self.size_bytes, Unset):
+      size_bytes = UNSET
+    else:
+      size_bytes = self.size_bytes
 
     size_mb: float | None | Unset
     if isinstance(self.size_mb, Unset):
@@ -77,6 +87,8 @@ class SubgraphSummary:
         "created_at": created_at,
       }
     )
+    if size_bytes is not UNSET:
+      field_dict["size_bytes"] = size_bytes
     if size_mb is not UNSET:
       field_dict["size_mb"] = size_mb
     if last_accessed is not UNSET:
@@ -98,6 +110,15 @@ class SubgraphSummary:
     status = d.pop("status")
 
     created_at = datetime.datetime.fromisoformat(d.pop("created_at"))
+
+    def _parse_size_bytes(data: object) -> int | None | Unset:
+      if data is None:
+        return data
+      if isinstance(data, Unset):
+        return data
+      return cast(int | None | Unset, data)
+
+    size_bytes = _parse_size_bytes(d.pop("size_bytes", UNSET))
 
     def _parse_size_mb(data: object) -> float | None | Unset:
       if data is None:
@@ -132,6 +153,7 @@ class SubgraphSummary:
       subgraph_type=subgraph_type,
       status=status,
       created_at=created_at,
+      size_bytes=size_bytes,
       size_mb=size_mb,
       last_accessed=last_accessed,
     )


### PR DESCRIPTION
## Summary

Regeneration picking up two API changes: the byte-precision subgraph size fields already merged on the API's `main`, and the storage-item documentation from RoboFinSystems/robosystems#1079 (`transient`/`orphan` item types, enforcement semantics for `usage_percentage`). Generated against the local stack at #1079's tip; if that PR changes in review, this regen will be refreshed.

## Changes

- **Regenerated `models/` only** — no `api/` or facade changes; sync and async paths unaffected.
- `SubgraphResponse`, `SubgraphSummary`: new optional `size_bytes`; `ListSubgraphsResponse`: new optional `total_size_bytes`. `size_mb` remains, documented as derived.
- `StorageItem`, `InstanceUsage`: docstring updates only — the new `transient` (blue-green build artifact) and `orphan` (unregistered leftover) item type values, and a note that `usage_percentage` derives from durable bytes. `type` was and remains a plain `str`, so the new values are shape-compatible.

## Compatibility

ADDITIVE. All new fields are optional (`| None | Unset = UNSET`); no removals, renames, signature changes, or requiredness flips — verified by reading the full emitted diff, not assumed from the regeneration. Rides the next minor.

## Testing

`just test-all` run this session: 519 passed, 17 skipped; ruff format, lint, and basedpyright clean. No packaging changes, so `just build-package` was not needed.
