### PR TITLE
chore(client): regenerate for upstream docstring and description cleanup

### DIFF
--- a/robosystems_client/graphql/schema.graphql
+++ b/robosystems_client/graphql/schema.graphql
@@ -1579,8 +1579,8 @@ type InformationBlockElement {
 """
 Connection (= Association) projection.
 
-Renamed at the API boundary to match Charlie's ontology vocabulary.
-The underlying storage table is still ``associations``.
+"Connection" is the ontology term used on the wire; the storage table is
+``associations`` (``models/extensions/association.py``).
 """
 type InformationBlockConnection {
   id: String!
@@ -1746,10 +1746,8 @@ type InformationBlockRuleVariable {
 """
 FactSet projection — period-specific instantiation of the Structure.
 
-The envelope carries one ``FactSetLite`` per block when a FactSet row
-exists for the requested period; legacy writes that pre-date FactSet
-stamping leave ``fact_set`` null until the expand pass starts
-populating those rows.
+The envelope carries one ``FactSetLite`` per block when a FactSet row exists
+for the requested period, and leaves ``fact_set`` null when none does.
 """
 type InformationBlockFactSet {
   id: String!
@@ -1764,7 +1762,7 @@ type InformationBlockFactSet {
   entityId: String!
 
   """
-  Back-pointer to the ``reports`` table while ``report_id`` still lives on facts. Drops out once the retirement migration lands.
+  Back-pointer to the parent row in ``reports``. Null when the FactSet does not belong to a report package.
   """
   reportId: String
 
@@ -1774,7 +1772,7 @@ type InformationBlockFactSet {
   scenarioId: String
 
   """
-  Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null for pre-feature historical FactSets.
+  Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor.
   """
   provenance: JSON
 }
@@ -1881,11 +1879,10 @@ type InformationBlockRendering {
 """
 One row of a server-side rendered statement.
 
-Mirrors :class:`FactRow` from the legacy
-:mod:`robosystems.operations.roboledger.reports.fact_grid` but lives at
-the API boundary so envelope consumers don't depend on the
-fact-grid module. ``values`` is one entry per period column in
-:class:`RenderingLite.periods`.
+Mirrors :class:`FactRow` in
+:mod:`robosystems.operations.roboledger.reports.fact_grid`, restated at the
+API boundary so envelope consumers don't depend on that module. ``values``
+holds one entry per period column in :class:`RenderingLite.periods`.
 """
 type InformationBlockRenderingRow {
   elementId: String!

--- a/robosystems_client/models/attribution_filter.py
+++ b/robosystems_client/models/attribution_filter.py
@@ -43,10 +43,9 @@ class AttributionFilter:
               FK; matched lines aggregate signed into the attributed fact for the
               period.
 
-              ``field`` is **legacy and ignored** — the flow tag used to live in
-              ``line_items.metadata[field]`` but has been promoted to the typed
-              ``flow_element_id`` FK. Retained for wire-compatibility; the engine no
-              longer reads it.
+              ``field`` is accepted but ignored: the flow tag lives in the typed
+              ``flow_element_id`` FK, not in JSONB metadata. It stays on the wire so
+              existing request bodies keep validating.
           target_element_id (None | str | Unset): Resolved element id for ``target_qname``. Null at create time; populated
               by the handler before persistence. Round-tripped in the envelope.
   """

--- a/robosystems_client/models/connection_lite.py
+++ b/robosystems_client/models/connection_lite.py
@@ -19,8 +19,8 @@ T = TypeVar("T", bound="ConnectionLite")
 class ConnectionLite:
   """Connection (= Association) projection.
 
-  Renamed at the API boundary to match Charlie's ontology vocabulary.
-  The underlying storage table is still ``associations``.
+  "Connection" is the ontology term used on the wire; the storage table is
+  ``associations`` (``models/extensions/association.py``).
 
       Attributes:
           id (str):

--- a/robosystems_client/models/custom_schema_definition.py
+++ b/robosystems_client/models/custom_schema_definition.py
@@ -23,11 +23,11 @@ T = TypeVar("T", bound="CustomSchemaDefinition")
 
 @_attrs_define
 class CustomSchemaDefinition:
-  """Custom schema definition for generic graphs.
+  """Custom node and relationship types for a generic graph.
 
-  This model allows you to define custom node types, relationship types, and properties
-  for graphs that don't fit the standard entity-based schema. Perfect for domain-specific
-  applications like inventory systems, org charts, project management, etc.
+  For graphs that don't fit the entity-based schema — inventory, org charts,
+  project management. ``extends`` names a base schema to build on, or is
+  omitted for a bare database.
 
       Attributes:
           name (str): Schema name

--- a/robosystems_client/models/delete_result.py
+++ b/robosystems_client/models/delete_result.py
@@ -14,13 +14,11 @@ class DeleteResult:
   """Shared response shape for delete / soft-delete operations.
 
   ``deleted=True`` means the operation succeeded (a row was deleted or
-  flipped). The handler returns 404 instead when the row didn't exist
-  to begin with — the response shape is never used to communicate "not
-  found".
+  flipped). A row that never existed gets a 404 — this shape never carries
+  "not found".
 
-  Defined once here to avoid OpenAPI components key collisions
-  between roboledger and roboinvestor (both surfaces produced
-  separate ``DeleteResult`` classes before consolidation).
+  Defined once here, and used by both roboledger and roboinvestor, so the
+  OpenAPI components key resolves to a single schema.
 
       Attributes:
           deleted (bool): `true` when the row was deleted in this call. Always `true` today — 404 covers the not-found

--- a/robosystems_client/models/error_response.py
+++ b/robosystems_client/models/error_response.py
@@ -14,20 +14,17 @@ T = TypeVar("T", bound="ErrorResponse")
 
 @_attrs_define
 class ErrorResponse:
-  """Standard error response format used across all API endpoints.
+  """Error body returned by every endpoint.
 
-  This model ensures consistent error responses for SDK generation
-  and client error handling.
+  Example:
+      {'code': 'RESOURCE_NOT_FOUND', 'detail': 'Resource not found', 'request_id': 'req_1234567890abcdef',
+          'timestamp': '2024-01-01T00:00:00Z'}
 
-      Example:
-          {'code': 'RESOURCE_NOT_FOUND', 'detail': 'Resource not found', 'request_id': 'req_1234567890abcdef',
-              'timestamp': '2024-01-01T00:00:00Z'}
-
-      Attributes:
-          detail (str): Human-readable error message explaining what went wrong
-          code (None | str | Unset): Machine-readable error code for programmatic handling
-          request_id (None | str | Unset): Unique request ID for tracking and debugging
-          timestamp (datetime.datetime | None | Unset): Timestamp when the error occurred
+  Attributes:
+      detail (str): Human-readable error message explaining what went wrong
+      code (None | str | Unset): Machine-readable error code for programmatic handling
+      request_id (None | str | Unset): Unique request ID for tracking and debugging
+      timestamp (datetime.datetime | None | Unset): Timestamp when the error occurred
   """
 
   detail: str

--- a/robosystems_client/models/fact_set_lite.py
+++ b/robosystems_client/models/fact_set_lite.py
@@ -20,10 +20,8 @@ T = TypeVar("T", bound="FactSetLite")
 class FactSetLite:
   """FactSet projection — period-specific instantiation of the Structure.
 
-  The envelope carries one ``FactSetLite`` per block when a FactSet row
-  exists for the requested period; legacy writes that pre-date FactSet
-  stamping leave ``fact_set`` null until the expand pass starts
-  populating those rows.
+  The envelope carries one ``FactSetLite`` per block when a FactSet row exists
+  for the requested period, and leaves ``fact_set`` null when none does.
 
       Attributes:
           id (str):
@@ -33,13 +31,13 @@ class FactSetLite:
           entity_id (str):
           structure_id (None | str | Unset):
           period_start (datetime.date | None | Unset):
-          report_id (None | str | Unset): Back-pointer to the ``reports`` table while ``report_id`` still lives on facts.
-              Drops out once the retirement migration lands.
+          report_id (None | str | Unset): Back-pointer to the parent row in ``reports``. Null when the FactSet does not
+              belong to a report package.
           scenario_id (None | str | Unset): Scenario axis (the forecast engine). NULL = actuals; non-NULL names the owning
               forecast block whose parallel universe this set belongs to.
           provenance (FactSetLiteProvenanceType0 | None | Unset): Typed ``FactProvenance`` descriptor (discriminated on
               ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced
-              as JSON, mirroring how mechanics is exposed. Null for pre-feature historical FactSets.
+              as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor.
   """
 
   id: str

--- a/robosystems_client/models/forecast_mechanics.py
+++ b/robosystems_client/models/forecast_mechanics.py
@@ -20,7 +20,7 @@ T = TypeVar("T", bound="ForecastMechanics")
 
 @_attrs_define
 class ForecastMechanics:
-  """Authored scenario container for ``block_type='forecast'`` (FP&A F-1).
+  """Authored scenario container for ``block_type='forecast'``.
 
   The block IS the scenario: its structure id is the ``scenario_id``
   every derived forward FactSet carries (NULL = actuals). The authored

--- a/robosystems_client/models/graph_limits_response.py
+++ b/robosystems_client/models/graph_limits_response.py
@@ -26,7 +26,7 @@ T = TypeVar("T", bound="GraphLimitsResponse")
 
 @_attrs_define
 class GraphLimitsResponse:
-  """Response model for comprehensive graph operational limits.
+  """Every operational limit that applies to a graph, and its usage.
 
   Attributes:
       graph_id (str): Graph database identifier

--- a/robosystems_client/models/instance_usage.py
+++ b/robosystems_client/models/instance_usage.py
@@ -20,8 +20,7 @@ T = TypeVar("T", bound="InstanceUsage")
 class InstanceUsage:
   """Aggregate storage usage across the dedicated instance.
 
-  Covers the parent graph, all subgraphs, DuckDB staging, and
-  future LanceDB vector indexes.
+  Covers the parent graph, all subgraphs, DuckDB staging, and vector indexes.
 
       Attributes:
           limit_gb (float): Soft storage limit for this tier in GB

--- a/robosystems_client/models/line_item_metadata_predicate.py
+++ b/robosystems_client/models/line_item_metadata_predicate.py
@@ -23,19 +23,17 @@ class LineItemMetadataPredicate:
   FK; matched lines aggregate signed into the attributed fact for the
   period.
 
-  ``field`` is **legacy and ignored** — the flow tag used to live in
-  ``line_items.metadata[field]`` but has been promoted to the typed
-  ``flow_element_id`` FK. Retained for wire-compatibility; the engine no
-  longer reads it.
+  ``field`` is accepted but ignored: the flow tag lives in the typed
+  ``flow_element_id`` FK, not in JSONB metadata. It stays on the wire so
+  existing request bodies keep validating.
 
       Attributes:
           values (list[str]): Flow-concept qnames that route to this filter's target concept. A LineItem matches when its
               ``flow_element_id`` is one of the elements named here AND the line falls within the rollforward's period.
           kind (Literal['line_item_metadata_field'] | Unset): Discriminator value selecting this predicate shape. Default:
               'line_item_metadata_field'.
-          field (str | Unset): Legacy/ignored. The flow tag now lives in the typed ``flow_element_id`` FK, not JSONB
-              metadata; the engine no longer reads this. Retained for wire-compatibility. Default:
-              'transaction_description_code'.
+          field (str | Unset): Accepted but ignored. The flow tag lives in the typed ``flow_element_id`` FK, not JSONB
+              metadata. Retained for wire-compatibility. Default: 'transaction_description_code'.
   """
 
   values: list[str]

--- a/robosystems_client/models/operation_envelope.py
+++ b/robosystems_client/models/operation_envelope.py
@@ -16,36 +16,20 @@ T = TypeVar("T", bound="OperationEnvelope")
 class OperationEnvelope:
   """Uniform response shape for every operation endpoint.
 
-  Every dispatch through an operation surface returns an envelope carrying
-  an ``op_<ULID>`` operation_id.  That id is the bridge to the platform's
-  monitoring surface: pass it to
+  Every dispatch carries an ``op_<ULID>`` operation_id, which is the bridge
+  to the monitoring surface: pass it to
   ``GET /v1/operations/{operation_id}/stream`` (see ``routers/operations.py``)
-  to subscribe to SSE progress events.  Sync commands complete in the
-  envelope itself; async commands (``status: "pending"``, HTTP 202) hand
-  off to a background worker and stream their tail through the same SSE
-  endpoint until completion.  Failed dispatches still mint an
+  to subscribe to SSE progress events. Sync commands complete in the envelope
+  itself (``status: "completed"``, HTTP 200); async commands
+  (``status: "pending"``, HTTP 202) hand off to a background worker and stream
+  their tail through that SSE endpoint. Failed dispatches still mint an
   ``operation_id`` so the audit log and any partial SSE events stay
   correlatable.
 
-  ``TResult`` parameterizes the ``result`` field so per-op response shapes
-  surface in OpenAPI. Operations that pin ``OperationSpec.result_type`` get
-  ``OperationEnvelope[YourEnvelope]`` as their response model; ops that
-  don't keep the default ``Any`` shape (`result: any | null` on the wire).
-
-  Fields:
-  - ``operation``: kebab-case command name (e.g. ``close-period``)
-  - ``operation_id``: ``op_``-prefixed ULID; always present, usable for
-    audit correlation and — for async commands — SSE subscription via
-    ``/v1/operations/{operation_id}/stream``
-  - ``status``: ``"completed"`` (sync, HTTP 200), ``"pending"``
-    (async, HTTP 202), or ``"failed"`` (error responses)
-  - ``result``: the domain-specific payload (the original Pydantic
-    response) or ``None`` for async/failed cases
-  - ``at``: ISO-8601 UTC timestamp of when the envelope was minted
-  - ``created_by``: user ID of the caller who initiated this operation
-  - ``idempotent_replay``: ``True`` when the dispatcher returned this
-    envelope from the idempotency cache (the underlying command did NOT
-    execute again)
+  ``TResult`` parameterizes ``result`` so per-op response shapes surface in
+  OpenAPI. Operations that pin ``OperationSpec.result_type`` get
+  ``OperationEnvelope[YourEnvelope]`` as their response model; the rest keep
+  the default ``Any`` shape (``result: any | null`` on the wire).
 
       Attributes:
           operation (str): Kebab-case operation name

--- a/robosystems_client/models/rendering_row_lite.py
+++ b/robosystems_client/models/rendering_row_lite.py
@@ -15,11 +15,10 @@ T = TypeVar("T", bound="RenderingRowLite")
 class RenderingRowLite:
   """One row of a server-side rendered statement.
 
-  Mirrors :class:`FactRow` from the legacy
-  :mod:`robosystems.operations.roboledger.reports.fact_grid` but lives at
-  the API boundary so envelope consumers don't depend on the
-  fact-grid module. ``values`` is one entry per period column in
-  :class:`RenderingLite.periods`.
+  Mirrors :class:`FactRow` in
+  :mod:`robosystems.operations.roboledger.reports.fact_grid`, restated at the
+  API boundary so envelope consumers don't depend on that module. ``values``
+  holds one entry per period column in :class:`RenderingLite.periods`.
 
       Attributes:
           element_id (str):

--- a/robosystems_client/models/schedule_mechanics.py
+++ b/robosystems_client/models/schedule_mechanics.py
@@ -20,12 +20,10 @@ T = TypeVar("T", bound="ScheduleMechanics")
 class ScheduleMechanics:
   """Closing-entry generator mechanics for ``block_type='schedule'``.
 
-  Reads directly from the typed ``structures.artifact_mechanics`` JSONB
-  column. ``entry_template`` and ``schedule_metadata`` are typed
-  sub-models (reusing the wire-level request shapes so OpenAPI emits one
-  canonical type per concept); the envelope builder falls back to
-  ``structures.metadata_`` for legacy Schedule rows that the tenant
-  backfill hasn't yet migrated to the typed column.
+  Reads the typed ``structures.artifact_mechanics`` JSONB column, falling back
+  to ``structures.metadata_`` for Schedule rows that lack it.
+  ``entry_template`` and ``schedule_metadata`` reuse the wire-level request
+  shapes so OpenAPI emits one canonical type per concept.
 
       Attributes:
           entry_template (EntryTemplateRequest):

--- a/robosystems_client/models/storage_item.py
+++ b/robosystems_client/models/storage_item.py
@@ -15,8 +15,8 @@ class StorageItem:
 
   Attributes:
       type_ (str): One of: graph, memory, subgraph, vectors, staging, transient (blue-green build artifact), orphan (a
-          `{parent}_*` database, vector index, or staging file with no row in the graph registry — reclaimable leftover of
-          a deleted subgraph)
+          `{parent}_*` database, vector index, or staging file with no row in the graph registry — leftover of a deleted
+          subgraph). Transient and orphan items are collected by the platform's daily storage-reclaim job.
       id (str): Database or index identifier
       bytes_ (int): Size in bytes
   """

--- a/robosystems_client/models/update_rollforward_arm.py
+++ b/robosystems_client/models/update_rollforward_arm.py
@@ -25,18 +25,16 @@ class UpdateRollforwardArm:
           payload (UpdateRollforwardRequest): Update mutable fields on a rollforward block.
 
               Editable: name, default_change_tag_qname, attribution_filters,
-              validation_mode. The BS source is fixed once the block is created
-              (changing it would invalidate every previously rendered period); to
-              change BS source, delete and re-create.
+              validation_mode. The BS source is fixed at creation — changing it would
+              invalidate every period already rendered — so switching BS source means
+              delete and re-create.
 
-              **Partial-update semantics**: omitted (``None``) fields mean "leave
-              unchanged" — there is no wire-level way to *clear* a previously set
-              default change tag or empty the attribution_filters list via this
-              endpoint. To remove the default tag entirely, delete and re-create
-              the rollforward block. The asymmetry is deliberate: an explicit
-              clear-sentinel adds wire-shape complexity for a use case that rarely
-              arises in practice (default tags are typically set during initial
-              authoring and only swapped, not removed).
+              **Partial-update semantics**: an omitted (``None``) field means "leave
+              unchanged". There is no wire-level way to *clear* the default change tag or
+              empty the attribution_filters list; delete and re-create the block instead.
+              The asymmetry is deliberate — a clear-sentinel costs wire-shape complexity
+              for a case that rarely arises, since default tags get swapped rather than
+              removed.
   """
 
   block_type: Literal["rollforward"]

--- a/robosystems_client/models/update_rollforward_request.py
+++ b/robosystems_client/models/update_rollforward_request.py
@@ -23,25 +23,23 @@ class UpdateRollforwardRequest:
   """Update mutable fields on a rollforward block.
 
   Editable: name, default_change_tag_qname, attribution_filters,
-  validation_mode. The BS source is fixed once the block is created
-  (changing it would invalidate every previously rendered period); to
-  change BS source, delete and re-create.
+  validation_mode. The BS source is fixed at creation — changing it would
+  invalidate every period already rendered — so switching BS source means
+  delete and re-create.
 
-  **Partial-update semantics**: omitted (``None``) fields mean "leave
-  unchanged" — there is no wire-level way to *clear* a previously set
-  default change tag or empty the attribution_filters list via this
-  endpoint. To remove the default tag entirely, delete and re-create
-  the rollforward block. The asymmetry is deliberate: an explicit
-  clear-sentinel adds wire-shape complexity for a use case that rarely
-  arises in practice (default tags are typically set during initial
-  authoring and only swapped, not removed).
+  **Partial-update semantics**: an omitted (``None``) field means "leave
+  unchanged". There is no wire-level way to *clear* the default change tag or
+  empty the attribution_filters list; delete and re-create the block instead.
+  The asymmetry is deliberate — a clear-sentinel costs wire-shape complexity
+  for a case that rarely arises, since default tags get swapped rather than
+  removed.
 
       Attributes:
           structure_id (str): Structure ID of the rollforward block.
           name (None | str | Unset):
           default_change_tag_qname (None | str | Unset): New default change tag qname. Pass a value to *change* the
-              default; omit (``None``) to leave unchanged. There is no wire-level way to clear a previously set default — see
-              the class docstring.
+              default; omit (``None``) to leave unchanged. There is no wire-level way to clear the default — see the class
+              docstring.
           attribution_filters (list[AttributionFilter] | None | Unset):
           validation_mode (None | Unset | UpdateRollforwardRequestValidationModeType0):
   """


### PR DESCRIPTION
## Summary

Regenerated against `robosystems` `main` after a repo-wide documentation scrub upstream (RoboFinSystems/robosystems#1081, #1082). The scrub trimmed docstrings and removed references to internal artifacts a public reader cannot resolve; a handful of those strings feed the OpenAPI spec and the GraphQL schema, so they propagate here.

**Description text only.** No operation was added or removed, no field renamed, no type or requiredness changed. Verified by filtering the diff for any non-comment line: the Python models diff contains zero changed assignment or type lines, and `sdk/types.gen.ts` contains zero changed non-JSDoc lines.

## What changed

- Field and model descriptions reworded, mostly shorter — history-framed notes ("previously X", "drops out once the retirement migration lands") replaced with present-tense statements of current behavior.
- Two descriptions corrected rather than trimmed: `FactSetLite.report_id` described a column that a landed migration had already dropped, and a rollforward field was labelled "legacy/ignored" when it is accepted-and-ignored.
- GraphQL schema snapshot picks up the same description changes, since the extensions schema derives descriptions from the upstream Pydantic models.

## Compatibility

Non-breaking and additive under the post-1.0 SDK contract. Callers need no changes; only inline documentation differs.

## Testing

Full gate clean — lint, format, typecheck, and the complete test suite. GraphQL codegen regenerates byte-identical output against the checked-in schema snapshot, so the drift gate is satisfied.
