### PR TITLE
chore(client): regenerate for FactProvenance arm list correction

### DIFF
--- a/robosystems_client/graphql/schema.graphql
+++ b/robosystems_client/graphql/schema.graphql
@@ -1772,7 +1772,7 @@ type InformationBlockFactSet {
   scenarioId: String
 
   """
-  Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor.
+  Typed ``FactProvenance`` descriptor (discriminated on ``origin``: pivot | schedule | derived | asserted | document | forecast | filed) recording how this FactSet's facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor.
   """
   provenance: JSON
 }

--- a/robosystems_client/models/fact_set_lite.py
+++ b/robosystems_client/models/fact_set_lite.py
@@ -36,8 +36,9 @@ class FactSetLite:
           scenario_id (None | str | Unset): Scenario axis (the forecast engine). NULL = actuals; non-NULL names the owning
               forecast block whose parallel universe this set belongs to.
           provenance (FactSetLiteProvenanceType0 | None | Unset): Typed ``FactProvenance`` descriptor (discriminated on
-              ``origin``: pivot | schedule | derived | asserted) recording how this FactSet's facts were constructed. Surfaced
-              as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no descriptor.
+              ``origin``: pivot | schedule | derived | asserted | document | forecast | filed) recording how this FactSet's
+              facts were constructed. Surfaced as JSON, mirroring how mechanics is exposed. Null when the FactSet carries no
+              descriptor.
   """
 
   id: str


### PR DESCRIPTION
## Summary

Regenerates the client against the current upstream API surface, refreshing the checked-in `schema.graphql` snapshot. Picks up the `FactProvenance` arm-list correction in the `FactSet.provenance` description (robosystems `48b0ecf1`, released in v1.7.4).

Documentation-only: the `origin` discriminator list in the `provenance` field description now reads `pivot | schedule | derived | asserted | document | forecast | filed` instead of the stale four-arm list.

## Changes

- `robosystems_client/graphql/schema.graphql` — refreshed snapshot (`InformationBlockFactSet.provenance` description)
- `robosystems_client/models/fact_set_lite.py` — regenerated docstring

## Compatibility

No public-surface change — the facades, models, and runtime behavior are unchanged. Patch-level; no deprecations, so no curated release notes required.

## Test plan

- [x] Pre-commit hook: ruff, format, basedpyright, 519 tests passed / 17 skipped
- [x] GraphQL drift gate regenerates clean from the updated schema snapshot