### PR TITLE
feat(client): regenerate for the backup encryption field removal

### DIFF
--- a/robosystems_client/api/backup/get_backup_download_url.py
+++ b/robosystems_client/api/backup/get_backup_download_url.py
@@ -87,11 +87,11 @@ def sync_detailed(
 ) -> Response[Any | BackupDownloadUrlResponse | HTTPValidationError]:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
-  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
-  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
-  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
-  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
+   Generate a temporary download URL for a backup. The filename carries the extension listed as
+  `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB database file
+  `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-compressed database
+  file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`,
+  `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):
@@ -128,11 +128,11 @@ def sync(
 ) -> Any | BackupDownloadUrlResponse | HTTPValidationError | None:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
-  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
-  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
-  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
-  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
+   Generate a temporary download URL for a backup. The filename carries the extension listed as
+  `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB database file
+  `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-compressed database
+  file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`,
+  `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):
@@ -164,11 +164,11 @@ async def asyncio_detailed(
 ) -> Response[Any | BackupDownloadUrlResponse | HTTPValidationError]:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
-  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
-  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
-  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
-  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
+   Generate a temporary download URL for a backup. The filename carries the extension listed as
+  `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB database file
+  `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-compressed database
+  file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`,
+  `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):
@@ -203,11 +203,11 @@ async def asyncio(
 ) -> Any | BackupDownloadUrlResponse | HTTPValidationError | None:
   """Get temporary download URL for backup
 
-   Generate a temporary download URL for a backup (unencrypted backups only). The filename carries the
-  extension listed as `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB
-  database file `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-
-  compressed database file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first:
-  `brew install zstd`, `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
+   Generate a temporary download URL for a backup. The filename carries the extension listed as
+  `download_extension` on the backup: `.lbug.zip` is a ZIP holding the LadybugDB database file
+  `{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single zstd-compressed database
+  file. Decompress the latter with `zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`,
+  `apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed.
 
   Args:
       graph_id (str):

--- a/robosystems_client/api/graph_operations/restore_backup.py
+++ b/robosystems_client/api/graph_operations/restore_backup.py
@@ -111,8 +111,9 @@ def sync_detailed(
 ) -> Response[ErrorResponse | OperationEnvelope]:
   """Restore Backup
 
-   Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
-  shared repositories.
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+  existing database is snapshotted, then overwritten. Monitor progress via SSE at
+  `/v1/operations/{operation_id}/stream`.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -152,8 +153,9 @@ def sync(
 ) -> ErrorResponse | OperationEnvelope | None:
   """Restore Backup
 
-   Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
-  shared repositories.
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+  existing database is snapshotted, then overwritten. Monitor progress via SSE at
+  `/v1/operations/{operation_id}/stream`.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -188,8 +190,9 @@ async def asyncio_detailed(
 ) -> Response[ErrorResponse | OperationEnvelope]:
   """Restore Backup
 
-   Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
-  shared repositories.
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+  existing database is snapshotted, then overwritten. Monitor progress via SSE at
+  `/v1/operations/{operation_id}/stream`.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.
@@ -227,8 +230,9 @@ async def asyncio(
 ) -> ErrorResponse | OperationEnvelope | None:
   """Restore Backup
 
-   Only encrypted backups can be restored. Not allowed on entity graphs (use `materialize` instead) or
-  shared repositories.
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+  existing database is snapshotted, then overwritten. Monitor progress via SSE at
+  `/v1/operations/{operation_id}/stream`.
 
   **Idempotency**: supply an `Idempotency-Key` header to make safe retries; replays within 24 hours
   return the same envelope. Reusing the key with a different body returns HTTP 409 Conflict.

--- a/robosystems_client/models/backup_create_request.py
+++ b/robosystems_client/models/backup_create_request.py
@@ -23,7 +23,6 @@ class BackupCreateRequest:
           is the hard ceiling: the storage lifecycle expires backup objects then regardless of the requested value.
           Default: 30.
       compression (bool | Unset): Enable compression (always enabled for optimal storage) Default: True.
-      encryption (bool | Unset): Enable encryption (encrypted backups cannot be downloaded) Default: False.
       schedule (None | str | Unset): Optional cron schedule for automated backups
   """
 
@@ -31,7 +30,6 @@ class BackupCreateRequest:
   backup_type: str | Unset = "full"
   retention_days: int | Unset = 30
   compression: bool | Unset = True
-  encryption: bool | Unset = False
   schedule: None | str | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -43,8 +41,6 @@ class BackupCreateRequest:
     retention_days = self.retention_days
 
     compression = self.compression
-
-    encryption = self.encryption
 
     schedule: None | str | Unset
     if isinstance(self.schedule, Unset):
@@ -63,8 +59,6 @@ class BackupCreateRequest:
       field_dict["retention_days"] = retention_days
     if compression is not UNSET:
       field_dict["compression"] = compression
-    if encryption is not UNSET:
-      field_dict["encryption"] = encryption
     if schedule is not UNSET:
       field_dict["schedule"] = schedule
 
@@ -81,8 +75,6 @@ class BackupCreateRequest:
 
     compression = d.pop("compression", UNSET)
 
-    encryption = d.pop("encryption", UNSET)
-
     def _parse_schedule(data: object) -> None | str | Unset:
       if data is None:
         return data
@@ -97,7 +89,6 @@ class BackupCreateRequest:
       backup_type=backup_type,
       retention_days=retention_days,
       compression=compression,
-      encryption=encryption,
       schedule=schedule,
     )
 

--- a/robosystems_client/models/backup_list_response.py
+++ b/robosystems_client/models/backup_list_response.py
@@ -25,6 +25,9 @@ class BackupListResponse:
       total_count (int):
       graph_id (str):
       is_shared_repository (bool | Unset): Whether this is a shared repository (limits apply) Default: False.
+      restore_supported (bool | Unset): Whether backups on this graph can be restored. False for entity graphs, which
+          are materialized from the extensions database (use the materialize operation instead), and for shared
+          repositories, which are platform-managed and download-only. Default: True.
       download_quota (DownloadQuota | None | Unset): Download quota for shared repositories
   """
 
@@ -32,6 +35,7 @@ class BackupListResponse:
   total_count: int
   graph_id: str
   is_shared_repository: bool | Unset = False
+  restore_supported: bool | Unset = True
   download_quota: DownloadQuota | None | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -48,6 +52,8 @@ class BackupListResponse:
     graph_id = self.graph_id
 
     is_shared_repository = self.is_shared_repository
+
+    restore_supported = self.restore_supported
 
     download_quota: dict[str, Any] | None | Unset
     if isinstance(self.download_quota, Unset):
@@ -68,6 +74,8 @@ class BackupListResponse:
     )
     if is_shared_repository is not UNSET:
       field_dict["is_shared_repository"] = is_shared_repository
+    if restore_supported is not UNSET:
+      field_dict["restore_supported"] = restore_supported
     if download_quota is not UNSET:
       field_dict["download_quota"] = download_quota
 
@@ -92,6 +100,8 @@ class BackupListResponse:
 
     is_shared_repository = d.pop("is_shared_repository", UNSET)
 
+    restore_supported = d.pop("restore_supported", UNSET)
+
     def _parse_download_quota(data: object) -> DownloadQuota | None | Unset:
       if data is None:
         return data
@@ -114,6 +124,7 @@ class BackupListResponse:
       total_count=total_count,
       graph_id=graph_id,
       is_shared_repository=is_shared_repository,
+      restore_supported=restore_supported,
       download_quota=download_quota,
     )
 

--- a/robosystems_client/models/backup_response.py
+++ b/robosystems_client/models/backup_response.py
@@ -27,15 +27,13 @@ class BackupResponse:
       node_count (int):
       relationship_count (int):
       backup_duration_seconds (float):
-      encryption_enabled (bool):
       compression_enabled (bool):
-      allow_export (bool):
       created_at (str):
       completed_at (None | str):
       expires_at (None | str):
       download_extension (None | str | Unset): Extension the download will carry, and therefore how to unpack it:
-          '.lbug.zip' is a ZIP holding the LadybugDB database file, '.lbug.zst' is zstd-compressed (`zstd -d`). Null when
-          the backup is encrypted and so cannot be downloaded.
+          '.lbug.zip' is a ZIP holding the LadybugDB database file, '.lbug.zst' is zstd-compressed (`zstd -d`). Null only
+          when the backup has no stored object yet.
   """
 
   backup_id: str
@@ -49,9 +47,7 @@ class BackupResponse:
   node_count: int
   relationship_count: int
   backup_duration_seconds: float
-  encryption_enabled: bool
   compression_enabled: bool
-  allow_export: bool
   created_at: str
   completed_at: None | str
   expires_at: None | str
@@ -81,11 +77,7 @@ class BackupResponse:
 
     backup_duration_seconds = self.backup_duration_seconds
 
-    encryption_enabled = self.encryption_enabled
-
     compression_enabled = self.compression_enabled
-
-    allow_export = self.allow_export
 
     created_at = self.created_at
 
@@ -116,9 +108,7 @@ class BackupResponse:
         "node_count": node_count,
         "relationship_count": relationship_count,
         "backup_duration_seconds": backup_duration_seconds,
-        "encryption_enabled": encryption_enabled,
         "compression_enabled": compression_enabled,
-        "allow_export": allow_export,
         "created_at": created_at,
         "completed_at": completed_at,
         "expires_at": expires_at,
@@ -154,11 +144,7 @@ class BackupResponse:
 
     backup_duration_seconds = d.pop("backup_duration_seconds")
 
-    encryption_enabled = d.pop("encryption_enabled")
-
     compression_enabled = d.pop("compression_enabled")
-
-    allow_export = d.pop("allow_export")
 
     created_at = d.pop("created_at")
 
@@ -197,9 +183,7 @@ class BackupResponse:
       node_count=node_count,
       relationship_count=relationship_count,
       backup_duration_seconds=backup_duration_seconds,
-      encryption_enabled=encryption_enabled,
       compression_enabled=compression_enabled,
-      allow_export=allow_export,
       created_at=created_at,
       completed_at=completed_at,
       expires_at=expires_at,


### PR DESCRIPTION
Regenerated against [RoboFinSystems/robosystems#refactor/backup-drop-encryption-flag](https://github.com/RoboFinSystems/robosystems/tree/refactor/backup-drop-encryption-flag), which retires the backup `encryption` flag.

The flag never encrypted anything at the application layer — it only suppressed downloads, and because it defaulted to `false`, the default backup was unrestorable. Restore is now gated on graph type instead, and every completed backup is downloadable. Objects remain encrypted at rest with S3 SSE-AES256 and are served over TLS through short-lived signed URLs.

## Contract changes

| Model | Change |
| --- | --- |
| `BackupListResponse` | **adds** `restore_supported: bool \| Unset = True` |
| `BackupCreateRequest` | **removes** `encryption` |
| `BackupResponse` | **removes** `encryption_enabled`, `allow_export` |

`restore_supported` is false for entity graphs (materialized from the extensions database — use `materialize`) and for shared repositories (platform-managed, download-only).

Also picks up description edits in `get_backup_download_url` and `restore_backup`.

## Versioning

Intended as a **minor**. Removing response fields breaks a consumer that reads them, which strict semver would call a major — but nothing reads them: the flag has no effect on any operation and `allow_export` was always its inverse. Called deliberately rather than carrying dead fields through a deprecation cycle.

An earlier regen widened `encryption_enabled` and `allow_export` from `bool` to `bool | Unset` — that would have been a genuine breaking read. Fixed upstream before this regen; the diff here is pure removals plus the one addition.

REST-only change, so `schema.graphql` is untouched and the codegen drift gate is unaffected.

## Verification

`just test-all` — 519 passed, 17 skipped; ruff, ruff format, basedpyright all clean.

Merge after the upstream API PR.