### PR TITLE
chore: regenerate against the v1.7.8 API surface

### DIFF
--- a/robosystems_client/api/graph_operations/restore_backup.py
+++ b/robosystems_client/api/graph_operations/restore_backup.py
@@ -111,7 +111,8 @@ def sync_detailed(
 ) -> Response[ErrorResponse | OperationEnvelope]:
   """Restore Backup
 
-   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Entity *subgraphs*
+  are restorable — they are written directly and have no materialization path. Destructive: the
   existing database is snapshotted, then overwritten. Monitor progress via SSE at
   `/v1/operations/{operation_id}/stream`.
 
@@ -153,7 +154,8 @@ def sync(
 ) -> ErrorResponse | OperationEnvelope | None:
   """Restore Backup
 
-   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Entity *subgraphs*
+  are restorable — they are written directly and have no materialization path. Destructive: the
   existing database is snapshotted, then overwritten. Monitor progress via SSE at
   `/v1/operations/{operation_id}/stream`.
 
@@ -190,7 +192,8 @@ async def asyncio_detailed(
 ) -> Response[ErrorResponse | OperationEnvelope]:
   """Restore Backup
 
-   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Entity *subgraphs*
+  are restorable — they are written directly and have no materialization path. Destructive: the
   existing database is snapshotted, then overwritten. Monitor progress via SSE at
   `/v1/operations/{operation_id}/stream`.
 
@@ -230,7 +233,8 @@ async def asyncio(
 ) -> ErrorResponse | OperationEnvelope | None:
   """Restore Backup
 
-   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the
+   Not allowed on entity graphs (use `materialize` instead) or shared repositories. Entity *subgraphs*
+  are restorable — they are written directly and have no materialization path. Destructive: the
   existing database is snapshotted, then overwritten. Monitor progress via SSE at
   `/v1/operations/{operation_id}/stream`.
 

--- a/robosystems_client/models/backup_list_response.py
+++ b/robosystems_client/models/backup_list_response.py
@@ -27,7 +27,8 @@ class BackupListResponse:
       is_shared_repository (bool | Unset): Whether this is a shared repository (limits apply) Default: False.
       restore_supported (bool | Unset): Whether backups on this graph can be restored. False for entity graphs, which
           are materialized from the extensions database (use the materialize operation instead), and for shared
-          repositories, which are platform-managed and download-only. Default: True.
+          repositories, which are platform-managed and download-only. True for subgraphs of an entity graph: only the
+          parent is materialized, so a subgraph has no other recovery path. Default: True.
       download_quota (DownloadQuota | None | Unset): Download quota for shared repositories
   """
 

--- a/robosystems_client/models/storage_summary.py
+++ b/robosystems_client/models/storage_summary.py
@@ -15,10 +15,9 @@ class StorageSummary:
 
   Attributes:
       graph_tier (str): Subscription tier
-      avg_storage_gb (float): Average storage in GB
+      avg_storage_gb (float): Time-weighted average storage in GB over the period
       max_storage_gb (float): Peak storage in GB
       min_storage_gb (float): Minimum storage in GB
-      total_gb_hours (float): Total GB-hours for billing
       measurement_count (int): Number of measurements taken
   """
 
@@ -26,7 +25,6 @@ class StorageSummary:
   avg_storage_gb: float
   max_storage_gb: float
   min_storage_gb: float
-  total_gb_hours: float
   measurement_count: int
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -39,8 +37,6 @@ class StorageSummary:
 
     min_storage_gb = self.min_storage_gb
 
-    total_gb_hours = self.total_gb_hours
-
     measurement_count = self.measurement_count
 
     field_dict: dict[str, Any] = {}
@@ -51,7 +47,6 @@ class StorageSummary:
         "avg_storage_gb": avg_storage_gb,
         "max_storage_gb": max_storage_gb,
         "min_storage_gb": min_storage_gb,
-        "total_gb_hours": total_gb_hours,
         "measurement_count": measurement_count,
       }
     )
@@ -69,8 +64,6 @@ class StorageSummary:
 
     min_storage_gb = d.pop("min_storage_gb")
 
-    total_gb_hours = d.pop("total_gb_hours")
-
     measurement_count = d.pop("measurement_count")
 
     storage_summary = cls(
@@ -78,7 +71,6 @@ class StorageSummary:
       avg_storage_gb=avg_storage_gb,
       max_storage_gb=max_storage_gb,
       min_storage_gb=min_storage_gb,
-      total_gb_hours=total_gb_hours,
       measurement_count=measurement_count,
     )
 


### PR DESCRIPTION
## What

One behavioural change, two documentation ones.

### `StorageSummary.total_gb_hours` removed

The server retired it in [robosystems#1107](https://github.com/RoboFinSystems/robosystems/pull/1107). It was a **storage-billing unit, and there is no storage billing** — the overage column is never written, the billing config has no storage entries, and storage is included in the tier. The field described a mechanism that had been removed.

`avg_storage_gb` is now documented as **time-weighted**, which is what it became: each reading weighted by the span since the previous one, so an irregular snapshot cadence doesn't skew it.

### Docstrings only

From [robosystems#1105](https://github.com/RoboFinSystems/robosystems/pull/1105): restore is allowed on entity **subgraphs** — they're written directly and have no materialization path, so a subgraph has no other recovery route. Touches `restore_backup` and `backup_list_response`.

## On the version

This removes a field from a response model, which the 1.0 contract would normally make a **major**. It rides as a patch deliberately:

**The server change already shipped.** The field is gone from the API, so a client still declaring it would be describing a response it can never receive. There's nothing to deprecate-then-remove — the client is catching up to the wire, not initiating the break. A deprecation cycle only makes sense when you control removal timing on both sides.

Worth knowing rather than assuming: if you'd want strictness here, the lever is server-side sequencing — deprecate the field in the API first, then remove it a cycle later, and the client follows in step.

No known consumer reads it (`robosystems-app` greps clean).

## Gate

519 passed, 17 skipped. `ruff check` + `ruff format --check` + `basedpyright` all clean.