### PR TITLE
Align positioning with the platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/robosystems-client.svg)](https://pypi.org/project/robosystems-client/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Official Python Client for the RoboSystems Financial Knowledge Graph API. Access comprehensive financial data including accounting transactions, financial reports, and advanced graph analytics through a type-safe, async-ready Python interface.
+Official Python client for the RoboSystems financial intelligence platform — accounting, financial reporting, and investment management over a knowledge graph API. Type-safe and async-ready, generated from the OpenAPI spec, with GraphQL reads and idempotent operation writes.
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "robosystems-client"
 version = "1.8.0"
-description = "Python client library for RoboSystems Financial Knowledge Graph API"
+description = "Python client library for the RoboSystems financial intelligence platform"
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [

--- a/robosystems_client/clients/README.md
+++ b/robosystems_client/clients/README.md
@@ -1,6 +1,6 @@
 # RoboSystems Python Client Extensions
 
-**Production-Ready Extensions** for the RoboSystems Financial Knowledge Graph API
+**Production-Ready Extensions** for the RoboSystems financial intelligence platform
 
 [![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
The README, the PyPI description, and the extensions README all opened on **"the RoboSystems Financial Knowledge Graph API"** — the naming the platform retired in favor of *"financial intelligence platform for accounting, financial reporting, and investment management."*

Part of a sweep aligning every surface on that framing: the repo README, the wiki, and the GitHub repo descriptions across the org were updated alongside this.

| File | Surface it feeds |
| --- | --- |
| `README.md` | GitHub repo page, PyPI long description |
| `pyproject.toml` | **PyPI package subtitle** — what an integrator sees first |
| `robosystems_client/clients/README.md` | Facade docs |

The `pyproject.toml` line is the one that mattered: it is the description rendered on the PyPI listing, so the drift was not cosmetic. It reaches PyPI on the next publish; the GitHub description is already live, so the two are briefly out of step until then.

No version bump, no public-surface change — neither tier is touched. `just test-all` green via the pre-commit gate: 526 passed, 17 skipped, 0 typecheck errors.