### PR TITLE
Regenerate for named SQL parameters and operator descriptions

### DIFF
--- a/robosystems_client/api/operator/auto_select_operator.py
+++ b/robosystems_client/api/operator/auto_select_operator.py
@@ -128,9 +128,11 @@ def sync_detailed(
 ) -> Response[Any | ErrorResponse | HTTPValidationError | OperatorResponse]:
   """Auto-select Operator for Query
 
-   Routes to the best operator for your query. Operators: `financial` (SEC, accounting), `research`
-  (deep analysis), `rag` (knowledge base, free). Credit cost by mode: `quick` 5-10, `standard` 15-25,
-  `extended` 30-75. Execution strategy (sync/SSE/async) auto-selected; override with
+   Routes to the best operator for your query. Operators: `cypher` (answers natural-language questions
+  by querying the graph; supports `quick`, `standard`, `extended`) and `mapping` (autonomous Chart of
+  Accounts → rs-gaap mapping; roboledger graphs only, `extended` only). `GET
+  /v1/graphs/{graph_id}/operator` lists what is registered. Credits are consumed by actual token
+  usage, not a fixed price per mode. Execution strategy (sync/SSE/async) auto-selected; override with
   `?mode=sync|async`.
 
   Args:
@@ -168,9 +170,11 @@ def sync(
 ) -> Any | ErrorResponse | HTTPValidationError | OperatorResponse | None:
   """Auto-select Operator for Query
 
-   Routes to the best operator for your query. Operators: `financial` (SEC, accounting), `research`
-  (deep analysis), `rag` (knowledge base, free). Credit cost by mode: `quick` 5-10, `standard` 15-25,
-  `extended` 30-75. Execution strategy (sync/SSE/async) auto-selected; override with
+   Routes to the best operator for your query. Operators: `cypher` (answers natural-language questions
+  by querying the graph; supports `quick`, `standard`, `extended`) and `mapping` (autonomous Chart of
+  Accounts → rs-gaap mapping; roboledger graphs only, `extended` only). `GET
+  /v1/graphs/{graph_id}/operator` lists what is registered. Credits are consumed by actual token
+  usage, not a fixed price per mode. Execution strategy (sync/SSE/async) auto-selected; override with
   `?mode=sync|async`.
 
   Args:
@@ -203,9 +207,11 @@ async def asyncio_detailed(
 ) -> Response[Any | ErrorResponse | HTTPValidationError | OperatorResponse]:
   """Auto-select Operator for Query
 
-   Routes to the best operator for your query. Operators: `financial` (SEC, accounting), `research`
-  (deep analysis), `rag` (knowledge base, free). Credit cost by mode: `quick` 5-10, `standard` 15-25,
-  `extended` 30-75. Execution strategy (sync/SSE/async) auto-selected; override with
+   Routes to the best operator for your query. Operators: `cypher` (answers natural-language questions
+  by querying the graph; supports `quick`, `standard`, `extended`) and `mapping` (autonomous Chart of
+  Accounts → rs-gaap mapping; roboledger graphs only, `extended` only). `GET
+  /v1/graphs/{graph_id}/operator` lists what is registered. Credits are consumed by actual token
+  usage, not a fixed price per mode. Execution strategy (sync/SSE/async) auto-selected; override with
   `?mode=sync|async`.
 
   Args:
@@ -241,9 +247,11 @@ async def asyncio(
 ) -> Any | ErrorResponse | HTTPValidationError | OperatorResponse | None:
   """Auto-select Operator for Query
 
-   Routes to the best operator for your query. Operators: `financial` (SEC, accounting), `research`
-  (deep analysis), `rag` (knowledge base, free). Credit cost by mode: `quick` 5-10, `standard` 15-25,
-  `extended` 30-75. Execution strategy (sync/SSE/async) auto-selected; override with
+   Routes to the best operator for your query. Operators: `cypher` (answers natural-language questions
+  by querying the graph; supports `quick`, `standard`, `extended`) and `mapping` (autonomous Chart of
+  Accounts → rs-gaap mapping; roboledger graphs only, `extended` only). `GET
+  /v1/graphs/{graph_id}/operator` lists what is registered. Credits are consumed by actual token
+  usage, not a fixed price per mode. Execution strategy (sync/SSE/async) auto-selected; override with
   `?mode=sync|async`.
 
   Args:

--- a/robosystems_client/api/operator/execute_specific_operator.py
+++ b/robosystems_client/api/operator/execute_specific_operator.py
@@ -131,8 +131,10 @@ def sync_detailed(
 ) -> Response[Any | ErrorResponse | HTTPValidationError | OperatorResponse]:
   """Execute Specific Operator
 
-   Available: `financial` (SEC filings, accounting), `research` (deep analysis), `rag` (retrieval, no
-  credits). Execution strategy auto-selected; override with `?mode=sync|async`.
+   Available: `cypher` (natural-language questions answered by querying the graph; RAG retrieval is one
+  of its capabilities, not a separate operator) and `mapping` (Chart of Accounts → rs-gaap mapping,
+  roboledger graphs only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. Execution
+  strategy auto-selected; override with `?mode=sync|async`.
 
   Args:
       graph_id (str):
@@ -172,8 +174,10 @@ def sync(
 ) -> Any | ErrorResponse | HTTPValidationError | OperatorResponse | None:
   """Execute Specific Operator
 
-   Available: `financial` (SEC filings, accounting), `research` (deep analysis), `rag` (retrieval, no
-  credits). Execution strategy auto-selected; override with `?mode=sync|async`.
+   Available: `cypher` (natural-language questions answered by querying the graph; RAG retrieval is one
+  of its capabilities, not a separate operator) and `mapping` (Chart of Accounts → rs-gaap mapping,
+  roboledger graphs only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. Execution
+  strategy auto-selected; override with `?mode=sync|async`.
 
   Args:
       graph_id (str):
@@ -208,8 +212,10 @@ async def asyncio_detailed(
 ) -> Response[Any | ErrorResponse | HTTPValidationError | OperatorResponse]:
   """Execute Specific Operator
 
-   Available: `financial` (SEC filings, accounting), `research` (deep analysis), `rag` (retrieval, no
-  credits). Execution strategy auto-selected; override with `?mode=sync|async`.
+   Available: `cypher` (natural-language questions answered by querying the graph; RAG retrieval is one
+  of its capabilities, not a separate operator) and `mapping` (Chart of Accounts → rs-gaap mapping,
+  roboledger graphs only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. Execution
+  strategy auto-selected; override with `?mode=sync|async`.
 
   Args:
       graph_id (str):
@@ -247,8 +253,10 @@ async def asyncio(
 ) -> Any | ErrorResponse | HTTPValidationError | OperatorResponse | None:
   """Execute Specific Operator
 
-   Available: `financial` (SEC filings, accounting), `research` (deep analysis), `rag` (retrieval, no
-  credits). Execution strategy auto-selected; override with `?mode=sync|async`.
+   Available: `cypher` (natural-language questions answered by querying the graph; RAG retrieval is one
+  of its capabilities, not a separate operator) and `mapping` (Chart of Accounts → rs-gaap mapping,
+  roboledger graphs only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. Execution
+  strategy auto-selected; override with `?mode=sync|async`.
 
   Args:
       graph_id (str):

--- a/robosystems_client/models/__init__.py
+++ b/robosystems_client/models/__init__.py
@@ -726,6 +726,7 @@ from .share_result_item import ShareResultItem
 from .skipped_forecast_lite import SkippedForecastLite
 from .skipped_metric_lite import SkippedMetricLite
 from .sql_statement_request import SqlStatementRequest
+from .sql_statement_request_parameters_type_1 import SqlStatementRequestParametersType1
 from .sql_statement_response import SqlStatementResponse
 from .sso_complete_request import SSOCompleteRequest
 from .sso_exchange_request import SSOExchangeRequest
@@ -1378,6 +1379,7 @@ __all__ = (
   "SkippedForecastLite",
   "SkippedMetricLite",
   "SqlStatementRequest",
+  "SqlStatementRequestParametersType1",
   "SqlStatementResponse",
   "SSOCompleteRequest",
   "SSOExchangeRequest",

--- a/robosystems_client/models/live_financial_statement_request.py
+++ b/robosystems_client/models/live_financial_statement_request.py
@@ -17,7 +17,7 @@ class LiveFinancialStatementRequest:
   """Request for live-financial-statement (OLTP, entity graphs only).
 
   Attributes:
-      statement_type (str): income_statement | balance_sheet | equity_statement
+      statement_type (str): income_statement | balance_sheet | cash_flow_statement | equity_statement
       period_start (datetime.date | None | Unset): Explicit window start. Overrides period_type/fiscal_year.
       period_end (datetime.date | None | Unset): Explicit window end. Overrides period_type/fiscal_year.
       period_type (None | str | Unset): annual | quarterly | instant (ignored when dates supplied)

--- a/robosystems_client/models/sql_statement_request.py
+++ b/robosystems_client/models/sql_statement_request.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+  from ..models.sql_statement_request_parameters_type_1 import (
+    SqlStatementRequestParametersType1,
+  )
+
 
 T = TypeVar("T", bound="SqlStatementRequest")
 
@@ -17,22 +23,29 @@ class SqlStatementRequest:
       sql (str): SQL query over the graph's columnar tables (DuckDB) — a relational lens on the same graph-centric
           data, often ahead of the materialized graph. Use ? placeholders or $param_name for dynamic values to prevent SQL
           injection.
-      parameters (list[Any] | None | Unset): Query parameters for safe value substitution. ALWAYS use parameters
-          instead of string concatenation.
+      parameters (list[Any] | None | SqlStatementRequestParametersType1 | Unset): Query parameters for safe value
+          substitution. ALWAYS use parameters instead of string concatenation. Pass a list for positional placeholders
+          (`?` or `$1`) and an object for named ones (`$param_name`) — the two forms cannot be mixed in one statement.
   """
 
   sql: str
-  parameters: list[Any] | None | Unset = UNSET
+  parameters: list[Any] | None | SqlStatementRequestParametersType1 | Unset = UNSET
 
   def to_dict(self) -> dict[str, Any]:
+    from ..models.sql_statement_request_parameters_type_1 import (
+      SqlStatementRequestParametersType1,
+    )
+
     sql = self.sql
 
-    parameters: list[Any] | None | Unset
+    parameters: dict[str, Any] | list[Any] | None | Unset
     if isinstance(self.parameters, Unset):
       parameters = UNSET
     elif isinstance(self.parameters, list):
       parameters = self.parameters
 
+    elif isinstance(self.parameters, SqlStatementRequestParametersType1):
+      parameters = self.parameters.to_dict()
     else:
       parameters = self.parameters
 
@@ -50,10 +63,16 @@ class SqlStatementRequest:
 
   @classmethod
   def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    from ..models.sql_statement_request_parameters_type_1 import (
+      SqlStatementRequestParametersType1,
+    )
+
     d = dict(src_dict)
     sql = d.pop("sql")
 
-    def _parse_parameters(data: object) -> list[Any] | None | Unset:
+    def _parse_parameters(
+      data: object,
+    ) -> list[Any] | None | SqlStatementRequestParametersType1 | Unset:
       if data is None:
         return data
       if isinstance(data, Unset):
@@ -66,7 +85,15 @@ class SqlStatementRequest:
         return parameters_type_0
       except (TypeError, ValueError, AttributeError, KeyError):
         pass
-      return cast(list[Any] | None | Unset, data)
+      try:
+        if not isinstance(data, dict):
+          raise TypeError()
+        parameters_type_1 = SqlStatementRequestParametersType1.from_dict(data)
+
+        return parameters_type_1
+      except (TypeError, ValueError, AttributeError, KeyError):
+        pass
+      return cast(list[Any] | None | SqlStatementRequestParametersType1 | Unset, data)
 
     parameters = _parse_parameters(d.pop("parameters", UNSET))
 

--- a/robosystems_client/models/sql_statement_request_parameters_type_1.py
+++ b/robosystems_client/models/sql_statement_request_parameters_type_1.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SqlStatementRequestParametersType1")
+
+
+@_attrs_define
+class SqlStatementRequestParametersType1:
+  """ """
+
+  additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+
+    field_dict: dict[str, Any] = {}
+    field_dict.update(self.additional_properties)
+
+    return field_dict
+
+  @classmethod
+  def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    d = dict(src_dict)
+    sql_statement_request_parameters_type_1 = cls()
+
+    sql_statement_request_parameters_type_1.additional_properties = d
+    return sql_statement_request_parameters_type_1
+
+  @property
+  def additional_keys(self) -> list[str]:
+    return list(self.additional_properties.keys())
+
+  def __getitem__(self, key: str) -> Any:
+    return self.additional_properties[key]
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    self.additional_properties[key] = value
+
+  def __delitem__(self, key: str) -> None:
+    del self.additional_properties[key]
+
+  def __contains__(self, key: str) -> bool:
+    return key in self.additional_properties


### PR DESCRIPTION
Routine regeneration against the current `main` API surface. Three changes came across, one of them a real type widening rather than prose.

## What changed

**`SqlStatementRequest.parameters` accepts an object as well as a list.** The API-side field is now `list[Any] | dict[str, Any] | None`, so named placeholders (`$param_name`) are expressible alongside positional ones (`?` / `$1`) — the two forms still cannot be mixed in one statement. Generation added `SqlStatementRequestParametersType1` (the object arm) and the union-parsing branches in `to_dict` / `from_dict`.

**Operator descriptions now name the operators that exist.** They advertised `financial`, `research`, and `rag` with fixed per-mode credit prices (`quick` 5-10, `standard` 15-25, `extended` 30-75). What is actually registered is `cypher` and `mapping`, and credits are consumed by real token usage, not a per-mode price. The new text also points at `GET /v1/graphs/{graph_id}/operator` as the live answer, so the docstring cannot drift the same way again.

**`LiveFinancialStatementRequest.statement_type`** lists `cash_flow_statement` among its statement types.

## Compatibility

Generated tier, additive: a widened request-field union and a new model export. No removals, no stable-tier change — nothing here is in the facades, the root exports, or the emit-path symbols the integration template imports. Rides a minor; no deprecation cycle and no curated release notes required.

## Verification

Each of the three source-side changes was confirmed present at `robosystems` `origin/main`, not just on a local feature branch, so the regeneration reflects merged API state.

`just test-all` green via the pre-commit gate: 526 passed, 17 skipped, ruff clean, 0 basedpyright errors.