### PR TITLE
Regenerate for purged report ids on the block result

### DIFF
--- a/robosystems_client/models/block_source_graph_result.py
+++ b/robosystems_client/models/block_source_graph_result.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,11 +25,14 @@ class BlockSourceGraphResult:
           any purge. Default: False.
       purged_report_count (int | Unset): Number of previously-shared reports deleted from this graph. Zero unless
           `purge` was set. Default: 0.
+      purged_report_ids (list[str] | Unset): Ids of the previously-shared reports deleted from this graph. Empty
+          unless `purge` was set.
   """
 
   block: BlockedSourceGraphResponse
   already_blocked: bool | Unset = False
   purged_report_count: int | Unset = 0
+  purged_report_ids: list[str] | Unset = UNSET
   additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
@@ -38,6 +41,10 @@ class BlockSourceGraphResult:
     already_blocked = self.already_blocked
 
     purged_report_count = self.purged_report_count
+
+    purged_report_ids: list[str] | Unset = UNSET
+    if not isinstance(self.purged_report_ids, Unset):
+      purged_report_ids = self.purged_report_ids
 
     field_dict: dict[str, Any] = {}
     field_dict.update(self.additional_properties)
@@ -50,6 +57,8 @@ class BlockSourceGraphResult:
       field_dict["already_blocked"] = already_blocked
     if purged_report_count is not UNSET:
       field_dict["purged_report_count"] = purged_report_count
+    if purged_report_ids is not UNSET:
+      field_dict["purged_report_ids"] = purged_report_ids
 
     return field_dict
 
@@ -64,10 +73,13 @@ class BlockSourceGraphResult:
 
     purged_report_count = d.pop("purged_report_count", UNSET)
 
+    purged_report_ids = cast(list[str], d.pop("purged_report_ids", UNSET))
+
     block_source_graph_result = cls(
       block=block,
       already_blocked=already_blocked,
       purged_report_count=purged_report_count,
+      purged_report_ids=purged_report_ids,
     )
 
     block_source_graph_result.additional_properties = d


### PR DESCRIPTION
## Summary

Blocking a source graph with `purge` now reports *which* reports it removed, not only how many. Regenerated against RoboFinSystems/robosystems#1126, which adds `purged_report_ids` to the block result so a recipient can reconcile exactly what left their graph instead of inferring it from a count.

## Changes

- `models/block_source_graph_result.py` — one new optional field, `purged_report_ids: list[str] | Unset`, with the `to_dict` / `from_dict` handling the generator emits for a list-typed optional. Sync and async paths are unaffected: this is a response model, not an endpoint.

That is the whole diff. Nothing under `clients/` (the hand-written facades) changed, and no endpoint was added, removed, or resignatured.

**The GraphQL SDL is unchanged** — `just refresh-schema` against a backend running that branch reported "already current (2473 lines)", so the ariadne-codegen models are untouched. The upstream change alters authorization on existing report reads, not the schema they expose.

## Compatibility

ADDITIVE

Compared the emitted model before classifying, per the template's warning. `purged_report_ids` is optional (`| Unset`, defaulting to `UNSET`), no existing field changed type or became required, and nothing was removed. `purged_report_count` is untouched and still populated, so a consumer reading only the count is unaffected.

Nothing here touches the stable tier — no facade, no root export, and none of the symbols `robosystems-integration-template` imports for its emit path.

## Testing

- `just test-all` — passed via the pre-commit hook: 526 passed / 17 skipped, ruff check, ruff format, basedpyright (0 errors).
- Verified by hand that the emitted description matches the corrected upstream text; an earlier regen carried a description that explained why the *server* also reads the field, which does not belong in published client docs.

## Release sequencing

**Do not publish before robosystems#1126 merges and deploys.** The field is optional, so a client ahead of the API is harmless at runtime — it simply never arrives — but until then the package would document a response field the deployed API does not return.

No version bump in this PR.
